### PR TITLE
Update rereference and test_features

### DIFF
--- a/examples/test_features.py
+++ b/examples/test_features.py
@@ -47,18 +47,7 @@ def est_features_run(PATH_RUN) -> None:
         if PATH_M1 is not None and os.path.isfile(PATH_M1) \
         else define_M1.set_M1(raw_arr.ch_names, raw_arr.get_channel_types())
 
-    ch_names = list(df_M1['name'])
-    refs = df_M1['rereference']
-
-    to_ref_idx = np.array(df_M1[(df_M1['used'] == 1)].index)
-
-    cortex_idx = np.where(df_M1.type == 'ecog')[0]
-    subcortex_idx = np.array(df_M1[(df_M1["type"] == 'seeg') | (df_M1['type'] == 'dbs')
-                                   & (df_M1['type'] == 'lfp')].index)
-
-    ref_here = rereference.RT_rereference(ch_names, refs, to_ref_idx,
-                                          cortex_idx, subcortex_idx,
-                                          split_data=False)
+    ref_here = rereference.RT_rereference(df_M1, split_data=False)
 
     LIMIT_LOW = 50000
     LIMIT_HIGH = 65000
@@ -66,23 +55,26 @@ def est_features_run(PATH_RUN) -> None:
 
     gen = generator.ieeg_raw_generator(ieeg_raw, settings, fs)
 
-    feature_idx = np.where(np.logical_and(np.array((df_M1["used"] == 1)),
-                                          np.array((df_M1["target"] == 0))))[0]
-
     resample_ = None
     if settings["methods"]["resample_raw"] is True:
         resample_ = resample.Resample(settings, fs)
         fs_new = settings["resample_raw_settings"]["resample_freq"]
+    else:
+        fs_new = fs
 
+    ch_names = df_M1['name'].to_numpy()
+    feature_idx, = np.where(np.logical_and(np.array((df_M1["used"] == 1)),
+                                           np.array((df_M1["target"] == 0))))
+    used_chs = ch_names[feature_idx].tolist()
     features_ = features.Features(s=settings, fs=fs_new, line_noise=line_noise,
-                                  channels=np.array(ch_names)[feature_idx])
+                                  channels=used_chs)
 
     # call now run_analysis.py
     df_ = run_analysis.run(gen, features_, settings, ref_here, feature_idx,
                            resample_)
 
     # resample_label
-    ind_label = np.where(df_M1["target"] == 1)[0]
+    ind_label, = np.where(df_M1["target"] == 1)
     offset_time = max([value[1] for value in settings[
         "bandpass_filter_settings"]["frequency_ranges"].values()])
     offset_start = np.ceil(offset_time/1000 * fs).astype(int)
@@ -122,6 +114,7 @@ def est_features_run(PATH_RUN) -> None:
     # save df_M1 file
     df_M1.to_csv(os.path.join(settings["out_path"], folder_name,
                               folder_name+"_DF_M1.csv"))
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
@timonmerk  So I was pulling all the information extraction from df_M1, like cortex_idx and subcortex_idx etc., into the rereference module, to make the actual analysis script (e.g. test_features) a bit cleaner. This got me thinking that we should maybe initialize the settings as a class, into which we load the settings.json and M1.tsv. We could then get the relevant information via functions e.g. ch_names(), used_chs(), cortex_idx(), out_path() etc. What do you think?
The pull request doesn't implement the class yet or anything, I only pulled the cortex_idx etc. into the rereference initialization.