### PR TITLE
Fix ClassMissingException

### DIFF
--- a/py_neuromodulation/nm_decode.py
+++ b/py_neuromodulation/nm_decode.py
@@ -62,7 +62,16 @@ class Decoder:
     VERBOSE : bool = False
 
     class ClassMissingException(Exception):
-        print("only one class present")
+        def __init__(
+            self, 
+            message="Only one class present.",
+        ) -> None:
+            self.message = message
+            super().__init__(self.message)
+
+        def __str__(self):
+            return self.message
+            
 
     def __init__(self,
                  features: pd.DataFrame,


### PR DESCRIPTION
ClassMissingException previously printed the message "only one class present" even when the module nm_decode was simply initialized. Now ClassMissingException only prints this message when an Exception is actually raised.
Additionally, an individual message can be passed upon raising the Error, to potentially discern where exactly in the module the Error was raised.