### PR TITLE
Add `target_keywords` as argument

### DIFF
--- a/examples/example_BIDS.py
+++ b/examples/example_BIDS.py
@@ -21,7 +21,10 @@ def run_example_BIDS():
                                        PATH_BIDS=PATH_BIDS,
                                        PATH_OUT=PATH_OUT,
                                        LIMIT_DATA=False,
-                                       VERBOSE=False)
+                                       VERBOSE=True,
+                                       target_keywords=("SQUARED_ROTATION",),
+                                       used_types=("ecog", "seeg")
+    )
 
     nm_BIDS.run_bids()
 
@@ -72,7 +75,7 @@ def run_example_BIDS():
 
     performances = feature_reader.run_ML_model(
         estimate_channels=True,
-        estimate_gridpoints=True,
+        estimate_gridpoints=False,
         estimate_all_channels_combined=True,
         save_results=True
     )

--- a/py_neuromodulation/nm_BidsStream.py
+++ b/py_neuromodulation/nm_BidsStream.py
@@ -1,3 +1,4 @@
+from typing import Optional, Iterable
 import os
 import pathlib
 import mne
@@ -36,7 +37,8 @@ class BidsStream(nm_stream.PNStream):
         LIMIT_DATA:bool = False,
         LIMIT_LOW:int = 0,
         LIMIT_HIGH:int = 10000,
-        used_types:list = ["ecog"]) -> None:
+        used_types: Optional[Iterable[str]] = ("ecog", "dbs", "seeg"),
+        target_keywords: Optional[Iterable[str]] = ("mov", "squared", "label")) -> None:
 
         super().__init__(PATH_SETTINGS=PATH_SETTINGS,
             PATH_NM_CHANNELS=PATH_NM_CHANNELS,
@@ -63,7 +65,8 @@ class BidsStream(nm_stream.PNStream):
                             ch_names=self.raw_arr.ch_names,
                             ch_types=self.raw_arr.get_channel_types(),
                             bads=self.raw_arr.info["bads"],
-                            used_types=used_types
+                            used_types=used_types,
+                            target_keywords=target_keywords
                             )
 
         if self.PATH_ANNOTATIONS:

--- a/py_neuromodulation/nm_stream.py
+++ b/py_neuromodulation/nm_stream.py
@@ -338,7 +338,7 @@ class PNStream(ABC):
                         kwargs.get('bads', None),
                         kwargs.get('used_types', None)]:
 
-            nm_channels = nm_define_nmchannels.set_channels_by_bids(
+            nm_channels = nm_define_nmchannels.set_channels(
                 ch_names=kwargs.get('ch_names'),
                 ch_types=kwargs.get('ch_types'),
                 bads=kwargs.get('bads'),

--- a/py_neuromodulation/nm_stream.py
+++ b/py_neuromodulation/nm_stream.py
@@ -342,7 +342,9 @@ class PNStream(ABC):
                 ch_names=kwargs.get('ch_names'),
                 ch_types=kwargs.get('ch_types'),
                 bads=kwargs.get('bads'),
-                used_types=kwargs.get('used_types'))
+                used_types=kwargs.get('used_types'),
+                target_keywords=kwargs.get('target_keywords')
+            )
         return nm_channels
 
     @staticmethod


### PR DESCRIPTION
@timonmerk
As you suggested in the last PR #162, I added `mov_substrs` as an argument to the function:
- I renamed it to `target_keywords`, because you might be decoding something else than movement, so the name is a bit more universal
- As default arguments I added `("mov", "squared", "label")`. I added label here again, so that the default value is a bit more universal and people are not restricted to movement or classification ("squared")
- I changed the default types of used_types and target_keywords to tuples, because probably the default values should be an immutable, right?
- I saw that you changed the default in nm_BidsStream to `used_types:list = ["ecog"]`. So the default in nm_BidsStream now corresponds to `ECOG_ONLY = True`, but before it was `False`. Is that intended? I don't have any preference for the default values, just wanted to double check that this was on purpose :)
- Lastly, I renamed the method from `set_channels_by_bids` to `set_channels`, because I don't think the function actually necessarily uses the BIDS format in its current implementation. But we could think about writing a wrapper in the future, in which you only provide the path to the BIDS `*_channels.tsv` file instead of the arguments `ch_names`, `ch_types` and `bads`.