### PR TITLE
Refactor bids stream

### DIFF
--- a/py_neuromodulation/nm_analysis.py
+++ b/py_neuromodulation/nm_analysis.py
@@ -384,6 +384,8 @@ class Feature_Reader:
         time_stack_n_samples=5,
         use_nested_cv=False,
         VERBOSE=False,
+        undersampling=False,
+        oversampling=False,
     ):
         if decoder is not None:
             self.decoder = decoder
@@ -408,6 +410,8 @@ class Feature_Reader:
                 time_stack_n_samples=time_stack_n_samples,
                 VERBOSE=VERBOSE,
                 use_nested_cv=use_nested_cv,
+                undersampling=undersampling,
+                oversampling=oversampling,
             )
 
     def run_ML_model(

--- a/py_neuromodulation/nm_analysis.py
+++ b/py_neuromodulation/nm_analysis.py
@@ -218,6 +218,7 @@ class Feature_Reader:
         epoch_len: int = 4,
         threshold: float = 0.1,
         normalize_data: bool = True,
+        RETURN_X_Y_epochs : bool = False
     ):
 
         filtered_df = self.feature_arr[
@@ -234,7 +235,7 @@ class Feature_Reader:
             threshold=threshold,
         )
 
-        nm_plots.plot_epochs_avg(
+        XY_epochs = nm_plots.plot_epochs_avg(
             X_epoch=X_epoch,
             y_epoch=y_epoch,
             epoch_len=epoch_len,
@@ -249,7 +250,10 @@ class Feature_Reader:
             save=True,
             OUT_PATH=self.feature_dir,
             feature_file=self.feature_file,
+            RETURN_X_Y_epochs=RETURN_X_Y_epochs
         )
+        if RETURN_X_Y_epochs:
+            return XY_epochs[0], XY_epochs[1]
 
     def plot_subject_grid_ch_performance(
         self,

--- a/py_neuromodulation/nm_plots.py
+++ b/py_neuromodulation/nm_plots.py
@@ -102,7 +102,7 @@ def plot_epochs_avg(
     save: bool = False,
     OUT_PATH: str = None,
     feature_file: str = None,
-):
+    RETURN_X_Y_epochs : bool = False):
 
     # cut channel name of for axis + "_" for more dense plot
     if cut_ch_name_cols and None not in (ch_name, feature_names):
@@ -162,6 +162,8 @@ def plot_epochs_avg(
         print("Feature epoch average figure saved to: " + str(plt_path))
     if show_plot is False:
         plt.close()
+    if RETURN_X_Y_epochs:
+        return X_epoch, y_epoch
 
 
 def plot_grid_elec_3d(

--- a/scripts/py_nm_batch_trd_analysis_stream.py
+++ b/scripts/py_nm_batch_trd_analysis_stream.py
@@ -1,6 +1,13 @@
 import os
 from sklearn import linear_model, metrics, model_selection, discriminant_analysis
 from sklearn.metrics import confusion_matrix, ConfusionMatrixDisplay
+from sklearn.metrics import mutual_info_score
+from sklearn.feature_selection import mutual_info_classif
+import pandas as pd
+import numpy as np
+from matplotlib import pyplot as plt
+import pickle
+
 from skopt import space as skopt_space
 import xgboost
 from py_neuromodulation import nm_GenericStream, nm_analysis, nm_decode
@@ -8,53 +15,157 @@ from py_neuromodulation import nm_GenericStream, nm_analysis, nm_decode
 
 def main():
 
+    res_dict = {}
     PATH_OUT = r"C:\Users\ICN_admin\Documents\TRD Analysis\features_epochs_nonorm"
-    RUN_NAME = "effspm8_JUN_EMO"
-    feature_reader = nm_analysis.Feature_Reader(
-        feature_dir=PATH_OUT, feature_file=RUN_NAME, binarize_label=False
-    )
+    for RUN_NAME in [
+        "effspm8_JUN_EMO",
+        "effspm8_KOR_EMO",
+        "effspm8_MIC_EMO",
+        "effspm8_NIL_EMO",
+        "effspm8_OHL_EMO",
+        "effspm8_SCH_EMO",
+        "effspm8_THI_EMO",
+        "effspm8_WES_EMO",
+    ]:
+        res_dict[RUN_NAME] = {}
+        feature_reader = nm_analysis.Feature_Reader(
+            feature_dir=PATH_OUT, feature_file=RUN_NAME, binarize_label=False
+        )
 
-    model = linear_model.LogisticRegression()
-    model = xgboost.XGBClassifier()
-    feature_reader.decoder = nm_decode.Decoder(
-        features=feature_reader.feature_arr,
-        label=feature_reader.label,
-        label_name=feature_reader.label_name,
-        used_chs=feature_reader.used_chs,
-        model=model,
-        eval_method=metrics.balanced_accuracy_score,
-        cv_method=model_selection.KFold(n_splits=3, shuffle=True),
-        # cv_method="NonShuffledTrainTestSplit",
-        get_movement_detection_rate=False,
-        min_consequent_count=2,
-        TRAIN_VAL_SPLIT=False,
-        RUN_BAY_OPT=False,
-        bay_opt_param_space=None,
-        use_nested_cv=False,
-        fs=feature_reader.settings["sampling_rate_features_hz"],
-        oversampling=False,
-        undersampling=True,
-    )
+        model = linear_model.LogisticRegression()
+        # model = xgboost.XGBClassifier()
+        feature_reader.decoder = nm_decode.Decoder(
+            features=feature_reader.feature_arr,
+            label=feature_reader.label,
+            label_name=feature_reader.label_name,
+            used_chs=feature_reader.used_chs,
+            model=model,
+            eval_method=metrics.balanced_accuracy_score,
+            cv_method=model_selection.KFold(n_splits=3, shuffle=True),
+            # cv_method="NonShuffledTrainTestSplit",
+            get_movement_detection_rate=False,
+            min_consequent_count=2,
+            TRAIN_VAL_SPLIT=False,
+            RUN_BAY_OPT=False,
+            bay_opt_param_space=None,
+            use_nested_cv=False,
+            fs=feature_reader.settings["sampling_rate_features_hz"],
+            oversampling=False,
+            undersampling=True,
+        )
 
-    performances = feature_reader.run_ML_model(
-        estimate_channels=True,
-        estimate_gridpoints=False,
-        estimate_all_channels_combined=True,
-        save_results=True,
-    )
+        performances = feature_reader.run_ML_model(
+            estimate_channels=True,
+            estimate_gridpoints=False,
+            estimate_all_channels_combined=True,
+            save_results=True,
+        )
 
-    class_labels = ["rest", "ntr", "pls", "unpls"]
-    cm = confusion_matrix(
-        feature_reader.decoder.ch_ind_results["Cg25R01"]["y_test"][0],
-        feature_reader.decoder.ch_ind_results["Cg25R01"]["y_test_pr"][0],
-        normalize="true"
-    )
+        feature_reader.label = feature_reader.feature_arr.iloc[:, -1]
+        feature_reader.label_name = feature_reader.feature_arr.columns[-1]
 
-    disp = ConfusionMatrixDisplay(confusion_matrix=cm, display_labels=class_labels)
-    disp.plot()
+        class_labels = ["rest", "ntr", "pls", "unpls"]
 
-    # feature_reader.decoder.ch_ind_results["Cg25R01"]["y_test_prfeature_reader"
-    print("Analysis finished")
+        # Problem hier: all_ch
+        ch_names = list(feature_reader.nm_channels.query("used == 1")["name"])
+        ch_names.append("all_ch_combined")
+
+        # plot feature importances
+        def get_mi_scores(df, label):
+            mi_res = mutual_info_classif(df, label)
+            mi_series = pd.Series(mi_res, df.columns)
+            mi_series_sorted = mi_series.sort_values(ascending=False)
+            return mi_series_sorted
+
+        # 4 is the columns ALL, so remove everything from df where ALL is not UNPLS
+        df_f_unpls_rest = feature_reader.decoder.features.iloc[
+            np.where(
+                (feature_reader.decoder.features.iloc[:, -4] == 2)
+                | (feature_reader.decoder.features.iloc[:, -4] == 3)
+            )[0]
+        ]
+        mi_series_sorted = get_mi_scores(
+            df_f_unpls_rest.iloc[:, :-5].fillna(0),
+            df_f_unpls_rest.iloc[:, -1],
+        )
+
+        for ch_name in list(ch_names):
+            if ch_name.startswith("all_ch") is False:
+                df_filtered = feature_reader.feature_arr[
+                    feature_reader.filter_features(
+                        feature_reader.feature_arr.columns, ch_name, None
+                    )
+                ]
+                data = np.expand_dims(np.array(df_filtered), axis=1)
+
+                X_epoch, y_epoch = feature_reader.get_epochs(
+                    data,
+                    feature_reader.label,
+                    epoch_len=4,
+                    sfreq=feature_reader.settings["sampling_rate_features_hz"],
+                    threshold=0.1,
+                )
+                y_test = np.concatenate(
+                    feature_reader.decoder.ch_ind_results[ch_name]["y_test"]
+                )
+                y_test_pr = np.concatenate(
+                    feature_reader.decoder.ch_ind_results[ch_name]["y_test_pr"]
+                )
+            else:
+                X_epoch = None
+                y_epoch = None
+                y_test = np.concatenate(feature_reader.decoder.all_ch_results["y_test"])
+                y_test_pr = np.concatenate(
+                    feature_reader.decoder.all_ch_results["y_test_pr"]
+                )
+            cm = confusion_matrix(
+                y_test,
+                y_test_pr,
+                normalize="true",
+            )
+
+            res_dict[RUN_NAME][ch_name] = {}
+            res_dict[RUN_NAME][ch_name]["cm"] = cm
+            res_dict[RUN_NAME][ch_name]["X_epoch"] = X_epoch
+            res_dict[RUN_NAME][ch_name]["y_epoch"] = y_epoch
+            res_dict[RUN_NAME][ch_name]["performances"] = performances[""][ch_name][
+                "performance_test"
+            ]
+            res_dict[RUN_NAME][ch_name]["y_test"] = y_test
+            res_dict[RUN_NAME][ch_name]["y_test_pr"] = y_test_pr
+            res_dict[RUN_NAME][ch_name]["mi_series_sorted"] = mi_series_sorted
+
+        PLT_ = False
+        if PLT_:
+            disp = ConfusionMatrixDisplay(
+                confusion_matrix=cm, display_labels=class_labels
+            )
+            disp.plot()
+
+            vals_plt = 20
+            plt.bar(np.arange(vals_plt), mi_series_sorted.values[:vals_plt])
+            plt.xticks(
+                np.arange(vals_plt), mi_series_sorted.index[:vals_plt], rotation=90
+            )
+            plt.tight_layout()
+            plt.show()
+
+            # check for NaN's
+            plt.imshow(feature_reader.decoder.features, aspect="auto")
+            plt.clim(-1, 1)
+            # without NaN's
+            df_without_nan = feature_reader.decoder.features[
+                feature_reader.decoder.features["Cg25R01_fooof_a_exp"].notna()
+            ].copy()
+            mi_series_sorted_without_nan = get_mi_scores(
+                df_without_nan.iloc[:, :23], df_without_nan.iloc[:, -4]
+            )
+
+        print(f"Analysis finished {ch_name}")
+
+    print("start plotting here")
+    with open("dict_res_out_PLS_UNPLS_MI.p", "wb") as handle:
+        pickle.dump(res_dict, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
 
 if __name__ == "__main__":

--- a/scripts/py_nm_batch_trd_analysis_stream.py
+++ b/scripts/py_nm_batch_trd_analysis_stream.py
@@ -1,0 +1,61 @@
+import os
+from sklearn import linear_model, metrics, model_selection, discriminant_analysis
+from sklearn.metrics import confusion_matrix, ConfusionMatrixDisplay
+from skopt import space as skopt_space
+import xgboost
+from py_neuromodulation import nm_GenericStream, nm_analysis, nm_decode
+
+
+def main():
+
+    PATH_OUT = r"C:\Users\ICN_admin\Documents\TRD Analysis\features_epochs_nonorm"
+    RUN_NAME = "effspm8_JUN_EMO"
+    feature_reader = nm_analysis.Feature_Reader(
+        feature_dir=PATH_OUT, feature_file=RUN_NAME, binarize_label=False
+    )
+
+    model = linear_model.LogisticRegression()
+    model = xgboost.XGBClassifier()
+    feature_reader.decoder = nm_decode.Decoder(
+        features=feature_reader.feature_arr,
+        label=feature_reader.label,
+        label_name=feature_reader.label_name,
+        used_chs=feature_reader.used_chs,
+        model=model,
+        eval_method=metrics.balanced_accuracy_score,
+        cv_method=model_selection.KFold(n_splits=3, shuffle=True),
+        # cv_method="NonShuffledTrainTestSplit",
+        get_movement_detection_rate=False,
+        min_consequent_count=2,
+        TRAIN_VAL_SPLIT=False,
+        RUN_BAY_OPT=False,
+        bay_opt_param_space=None,
+        use_nested_cv=False,
+        fs=feature_reader.settings["sampling_rate_features_hz"],
+        oversampling=False,
+        undersampling=True,
+    )
+
+    performances = feature_reader.run_ML_model(
+        estimate_channels=True,
+        estimate_gridpoints=False,
+        estimate_all_channels_combined=True,
+        save_results=True,
+    )
+
+    class_labels = ["rest", "ntr", "pls", "unpls"]
+    cm = confusion_matrix(
+        feature_reader.decoder.ch_ind_results["Cg25R01"]["y_test"][0],
+        feature_reader.decoder.ch_ind_results["Cg25R01"]["y_test_pr"][0],
+        normalize="true"
+    )
+
+    disp = ConfusionMatrixDisplay(confusion_matrix=cm, display_labels=class_labels)
+    disp.plot()
+
+    # feature_reader.decoder.ch_ind_results["Cg25R01"]["y_test_prfeature_reader"
+    print("Analysis finished")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/py_nm_batch_trd_data.py
+++ b/scripts/py_nm_batch_trd_data.py
@@ -233,8 +233,9 @@ PATH_DATA = r"C:\Users\ICN_admin\Documents\TRD Analysis"
 def main():
 
     files = [f for f in os.listdir(PATH_DATA) if "_edit" in f]
-    #for f in files:
+    # for f in files:
     #    run_patient_GenericStream(f)
+    files.remove("effspm8_KSC_EMO_edit.mat")
     pool = Pool(processes=len(files))
     pool.map(run_patient_GenericStream, files)
 

--- a/scripts/py_nm_trd_post_analysis.py
+++ b/scripts/py_nm_trd_post_analysis.py
@@ -1,0 +1,306 @@
+from matplotlib import pyplot as plt
+import seaborn as sb
+from sklearn.metrics import confusion_matrix, ConfusionMatrixDisplay
+import pandas as pd
+import numpy as np
+import pickle
+from scipy import stats
+import os
+import sys
+
+from py_neuromodulation import nm_plots, nm_analysis
+
+sys.path.append(r"C:\Users\ICN_admin\Documents\icn\icn_stats")
+import icn_stats
+
+
+def plot_df_subjects(
+    df, PATH_OUT, x_col="sub", y_col="performance_test", hue="all combined"
+):
+    alpha_box = 0.4
+    plt.figure(figsize=(5, 3), dpi=300)
+    sb.boxplot(
+        x=x_col,
+        y=y_col,
+        hue=hue,
+        data=df,
+        palette="viridis",
+        showmeans=False,
+        boxprops=dict(alpha=alpha_box),
+        showcaps=True,
+        showbox=True,
+        showfliers=False,
+        notch=False,
+        whiskerprops={"linewidth": 2, "zorder": 10, "alpha": alpha_box},
+        capprops={"alpha": alpha_box},
+        medianprops=dict(linestyle="-.", linewidth=5, color="gray", alpha=alpha_box),
+    )
+
+    ax = sb.stripplot(
+        x=x_col,
+        y=y_col,
+        hue=hue,
+        data=df,
+        palette="viridis",
+        dodge=True,
+        s=5,
+    )
+
+    # When creating the legend, only use the first two elements
+    # to effectively remove the last two.
+    handles, labels = ax.get_legend_handles_labels()
+    l = plt.legend(
+        handles[0:2], labels[0:2], bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.0
+    )
+    plt.title("subject specific channel performances")
+    plt.ylabel(y_col)
+    plt.xticks(rotation=90)
+    plt.savefig(
+        os.path.join(PATH_OUT, "all_sub_performances.png"),
+        bbox_inches="tight",
+    )
+
+
+def main():
+
+    PATH_OUT = r"C:\Users\ICN_admin\Documents\TRD Analysis\features_epochs_nonorm"
+    feature_reader = nm_analysis.Feature_Reader(
+        feature_dir=PATH_OUT, feature_file="effspm8_JUN_EMO", binarize_label=False
+    )
+
+    with open("dict_res_out_PLS_UNPLS_MI.p", "rb") as handle:
+        d = pickle.load(handle)
+
+    class_labels = ["rest", "ntr", "pls", "unpls"]
+
+    depression_scores = {
+        "BDI24_am": {
+            "JUN": 37,
+            "KOR": 36,
+            "MIC": 32,
+            "NIL": 37,
+            "OHL": 1,
+            "SCH": 31,
+            "THI": 12,
+            "WES": 52,
+        },
+        "HAMD24_24": {
+            "JUN": 33,
+            "KOR": 27,
+            "MIC": 22,
+            "NIL": 29,
+            "OHL": 9,
+            "SCH": 16,
+            "THI": 7,
+            "WES": 33,
+        },
+    }
+
+    df = pd.DataFrame()
+    for run in d.keys():
+        for ch in d[run].keys():
+
+            if ch.startswith("all_ch_"):
+                ALL_COMB = True
+            else:
+                ALL_COMB = False
+            df = df.append(
+                {
+                    "performance_test": d[run][ch]["performances"],
+                    "sub": run[len("effspm8_") : len("effspm8_") + 3],
+                    "ch": ch,
+                    "all_comb": ALL_COMB,
+                    "BDI": depression_scores["BDI24_am"][
+                        run[len("effspm8_") : len("effspm8_") + 3]
+                    ],
+                    "HAMD": depression_scores["HAMD24_24"][
+                        run[len("effspm8_") : len("effspm8_") + 3]
+                    ],
+                },
+                ignore_index=True,
+            )
+
+    print("plot mean performances")
+
+    # plot depression correlation
+    metric = "HAMD"
+    df_plt = df.query("all_comb == False").groupby("sub").apply("mean")
+    df_plt = df.query("all_comb == True")
+    rho, p = icn_stats.permutationTestSpearmansRho(
+        df_plt["performance_test"],
+        df_plt[metric],
+        False,
+        "R^2",
+        5000,
+    )
+    sb.regplot(x="performance_test", y=metric, data=df_plt)
+    plt.title(f"Accuracy~{metric} p={np.round(p, 2)} rho={np.round(rho, 2)}")
+
+    cm = []
+    x_epoch = []
+    y_epoch = []
+    y_pr = []
+    y_te = []
+
+    mi_series = []
+
+    for run in d.keys():
+        for ch in d[run].keys():
+            cm.append(d[run][ch]["cm"])
+            if ch.startswith("all") is False:
+                x_epoch.append(np.squeeze(d[run][ch]["X_epoch"].mean(axis=0)))
+                y_epoch.append(d[run][ch]["y_epoch"].mean(axis=0))
+            else:
+                y_pr.append(d[run][ch]["y_test_pr"])
+                y_te.append(d[run][ch]["y_test"])
+        mi_series.append(d[run][ch]["mi_series_sorted"])
+
+    # time plot
+    y_pr_ = np.concatenate(y_pr)
+    y_te_ = np.concatenate(y_te)
+    y_te_[np.where(y_te_ != 3)[0]] = 0
+    X_, y_ = feature_reader.get_epochs(
+        np.expand_dims(y_pr_, axis=(1, 2)), y_te_, epoch_len=4, sfreq=10, threshold=0.1
+    )
+    y_unpls = np.squeeze(X_).mean(axis=0)
+
+    # 0 - REST, 1 - NTR, 2 - PLS, 3 - UNPLS
+    y_te_ = np.concatenate(y_te)
+    y_te_[np.where(y_te_ != 2)[0]] = 0
+    X_, y_ = feature_reader.get_epochs(
+        np.expand_dims(y_pr_, axis=(1, 2)), y_te_, epoch_len=4, sfreq=10, threshold=0.1
+    )
+    y_pls = np.squeeze(X_).mean(axis=0)
+
+    y_te_ = np.concatenate(y_te)
+    y_te_[np.where(y_te_ != 1)[0]] = 0
+    X_, y_ = feature_reader.get_epochs(
+        np.expand_dims(y_pr_, axis=(1, 2)), y_te_, epoch_len=4, sfreq=10, threshold=0.1
+    )
+    y_ntr = np.squeeze(X_).mean(axis=0)
+
+    y_te_ = np.concatenate(y_te)
+    y_te_[np.where(y_te_ == 0)[0]] = 5
+    y_te_[np.where(y_te_ != 5)[0]] = 0
+    X_, y_ = feature_reader.get_epochs(
+        np.expand_dims(y_pr_, axis=(1, 2)), y_te_, epoch_len=4, sfreq=10, threshold=0.1
+    )
+    y_rest = np.squeeze(X_).mean(axis=0)
+
+    plt.figure(figsize=(7, 4), dpi=300)
+    plt.plot(y_rest, linewidth=2, color="black", label="rest")
+    plt.plot(y_ntr, linewidth=2, color="gray", label="ntr")
+    plt.plot(y_pls, linewidth=2, color="blue", label="pls")
+    plt.plot(y_unpls, linewidth=2, color="green", label="unpls")
+    plt.xticks(np.arange(0, 40, 2), np.round(np.arange(-2, 2, 0.2), 2))
+    plt.xlabel("Time [s]")
+    plt.legend()
+    plt.ylabel("Prediction")
+    plt.title(
+        "XGBOOST mean predictions all channels\n 0 - REST, 1 - NTR, 2 - PLS, 3 - UNPLS"
+    )
+    plt.tight_layout()
+    plt.show()
+
+    print("plot")
+
+    # plot best
+    best_series = d["effspm8_SCH_EMO"]["Cg25L23"]["mi_series_sorted"]
+    best_series = best_series.reset_index()
+    best_series[best_series["index"].str.startswith("Cg25L23")].set_index(
+        "index"
+    ).plot.bar()
+    plt.ylabel("Mutual Information")
+    plt.title("Sorted Best subject ch Cg25L23 MI feature scores")
+    plt.tight_layout()
+
+    # plot mean all
+    df_mean_sorted = (
+        pd.concat(mi_series, axis=1).mean(axis=1).sort_values(ascending=False)
+    )
+    df_mean_sorted.iloc[:20].plot.bar()
+    plt.ylabel("Mutual Information")
+    plt.title("Sorted Mean subject MI feature scores")
+    plt.tight_layout()
+
+    disp = ConfusionMatrixDisplay(
+        confusion_matrix=np.array(cm).mean(axis=0), display_labels=class_labels
+    )
+    disp.plot()
+
+    # plot best confusion matrix
+    disp = ConfusionMatrixDisplay(
+        confusion_matrix=np.array(d["effspm8_SCH_EMO"]["Cg25L23"]["cm"]),
+        display_labels=class_labels,
+    )
+    disp.plot()
+
+    plot_df_subjects(
+        df, PATH_OUT, x_col="sub", y_col="performance_test", hue="all_comb"
+    )
+
+    # have a look at the mi rates scors: in total there are 23 features per channel
+    # take average series of all subjects and sort?
+
+    # plot best
+    x_best = stats.zscore(
+        np.nan_to_num(
+            np.squeeze(d["effspm8_SCH_EMO"]["Cg25L23"]["X_epoch"].mean(axis=0))
+        ),
+        axis=1,
+    )
+    y_best = d["effspm8_SCH_EMO"]["Cg25L23"]["y_epoch"]
+    plot_epoch(x_best.T, y_best, x_best.T)
+
+    # plot all
+    plot_epoch(x_epoch, y_epoch)
+
+    def plot_epoch(x_epoch, y_epoch, X_epoch_mean=None):
+        epoch_len = 4
+        feature_names = [f[8:] for f in feature_reader.feature_arr.columns[:23]]
+        label_name = "UNPLS"
+        X_epoch = np.array(x_epoch)
+        sfreq = 10
+        if X_epoch_mean is None:
+            X_epoch_mean = stats.zscore(
+                np.nan_to_num(np.nanmean(np.squeeze(X_epoch), axis=0)), axis=0
+            ).T
+        y_epoch = np.stack(np.array(y_epoch))
+        plt.figure(figsize=(6, 6))
+        plt.subplot(211)
+        plt.imshow(X_epoch_mean, aspect="auto")
+        plt.yticks(np.arange(0, len(feature_names), 1), feature_names)
+        plt.xticks(
+            np.arange(0, X_epoch.shape[1], 1),
+            np.round(np.arange(-epoch_len / 2, epoch_len / 2, 1 / sfreq), 2),
+            rotation=90,
+        )
+        plt.gca().invert_yaxis()
+        plt.xlabel("Time [s]")
+        str_title = "UNPLS aligned features mean all channels"
+        plt.title(str_title)
+
+        plt.subplot(212)
+        for i in range(y_epoch.shape[0]):
+            plt.plot(y_epoch[i, :], color="black", alpha=0.4)
+        plt.plot(
+            y_epoch.mean(axis=0),
+            color="black",
+            alpha=1,
+            linewidth=3.0,
+            label="mean target",
+        )
+        plt.legend()
+        plt.ylabel("target")
+        plt.title(label_name)
+        plt.xticks(
+            np.arange(0, X_epoch.shape[1], 1),
+            np.round(np.arange(-epoch_len / 2, epoch_len / 2, 1 / sfreq), 2),
+            rotation=90,
+        )
+        plt.xlabel("Time [s]")
+        plt.tight_layout()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Main change: Generalize Bids Stream to Generic Stream class

I think for many problems data in in BIDS format won't be available. This leaves the main requirements of the ABC nm_stream to be:
 - channel names
 - channel types
 - bad channels
 - rereferencing
 - fs 
 - line_noise
and subsequently defintion of a "data" np array for offline processing.

Thus I renamed `nm_BidsStream` to be `nm_GenericStream`.

Also `scripts/pn_nm_batch_trd_data.py` shows an example of utilizing epoch based data into a "stream" of data. 
This has implications of epoch discontinuities, since concatenating might not be optimal in some cases.

The advantages are though that the general pipeline is followed one to one compared to the "online" pipeline, so all pipeline code, analysis, potting, decoding stays the same.
