### PR TITLE
refactor offline stream

### DIFF
--- a/examples/example_BIDS.py
+++ b/examples/example_BIDS.py
@@ -31,7 +31,14 @@ def run_example_BIDS():
     PATH_BIDS = os.path.abspath(os.path.join("examples", "data"))
     PATH_OUT = os.path.abspath(os.path.join("examples", "data", "derivatives"))
 
-    raw, _, _, _ = nm_IO.read_BIDS_data(
+    (
+        raw,
+        data,
+        sfreq,
+        line_noise,
+        coord_list,
+        coord_names,
+    ) = nm_IO.read_BIDS_data(
         PATH_RUN=PATH_RUN, BIDS_PATH=PATH_BIDS, datatype=datatype
     )
 
@@ -45,15 +52,25 @@ def run_example_BIDS():
         target_keywords=("SQUARED_ROTATION",),
     )
 
-    nm_BIDS = nm.BidsStream(
+    stream = nm.Stream(
         settings=None,
         nm_channels=nm_channels,
-        path_out=PATH_OUT,
         path_grids=None,
         verbose=True,
     )
 
-    nm_BIDS.run(filepath=PATH_RUN, bids_root=PATH_BIDS, datatype=datatype)
+    stream.init_stream(
+        sfreq=sfreq,
+        line_noise=line_noise,
+        coord_list=coord_list,
+        coord_names=coord_names,
+    )
+
+    stream.run(
+        data=data,
+        out_path_root=PATH_OUT,
+        folder_name=RUN_NAME,
+    )
 
     # init analyzer
     feature_reader = nm_analysis.Feature_Reader(
@@ -118,7 +135,7 @@ def run_example_BIDS():
     # performance_dict = feature_reader.read_results(read_grid_points=True, read_channels=True,
     #                                               read_all_combined=False,
     #                                               read_mov_detection_rates=True)
-    if nm_BIDS.settings["methods"]["project_cortex"] is True:
+    if stream.settings["methods"]["project_cortex"] is True:
         feature_reader.plot_subject_grid_ch_performance(
             performance_dict=performances, plt_grid=True
         )

--- a/py_neuromodulation/__init__.py
+++ b/py_neuromodulation/__init__.py
@@ -6,4 +6,4 @@ from . import (
     nm_across_patient_decoding,
     nm_stream_offline,
 )
-from .nm_stream_offline import Stream, BidsStream
+from .nm_stream_offline import Stream

--- a/py_neuromodulation/nm_filter.py
+++ b/py_neuromodulation/nm_filter.py
@@ -100,7 +100,7 @@ class NotchFilter:
     def __init__(
         self,
         sfreq: int | float,
-        line_noise: int = 50,
+        line_noise: int,
         notch_widths: int | np.ndarray | None = 3,
         trans_bandwidth: int = 15,
     ) -> None:


### PR DESCRIPTION
I worked on some refactoring based on the previous PR:

  - move `folder_name` and `out_path_root` (former `path_out`) to `run` function
  - remove `BidsStream` from `nm_stream_offline`
  - add to `nm_IO` `get_coord_list` function for getting BIDS coordinates information and move call into def `read_BIDS_data`
  - add `init_stream` function in `nm_stream_abc` 

The last point solves the following issues:
 - the previous `set_run` method was called from the `run` method, in this way all parameters for the specific "nm_" feature and preprocessing parameters would have to be supplied to the `run` function, so the `init_stream` method decouples this; in this way e.g. `nm_resample.Resample` or `nm_filter.NotchFilter` can be supplied externally to the stream.
 - the `coords` parameter can thus be specified in a general setting, and not just through BIDS
 - the `init_stream` function creates a clear location where `sfreq` and `line_noise` are specified 

After refactoring the above method I realized that the `BidsStream` class is exactly the same as the `Stream` class. So I removed `BidsStream`. All the Bids specific information are now extracted externally and supplied via parameters.

@richardkoehler I would appreciate your thoughts on this :) 

One further refactor step would be looking into how "overloading" of the `run` function could be done, since the `folder_out`and `out_path_root` parameters are always the same in every instance. Probably `**kwargs` might be an option.