### PR TITLE
Add training routine

### DIFF
--- a/packages/realtime_decoding/src/realtime_decoding/run_decoding.py
+++ b/packages/realtime_decoding/src/realtime_decoding/run_decoding.py
@@ -205,6 +205,7 @@ class ProcessManager:
             path_grids=None,
             line_noise=50,
             verbose=self.verbose,
+            training_enabled=True
         )
         decoder = realtime_decoding.Decoder(
             queue_decoding=self.queue_decoding,

--- a/packages/realtime_decoding/src/realtime_decoding/trainer.py
+++ b/packages/realtime_decoding/src/realtime_decoding/trainer.py
@@ -1,0 +1,19 @@
+"""
+Read saved features from timeflux .hdf5 file and train model
+"""
+from sklearn import linear_model
+import pickle
+import pandas as pd
+
+
+if __name__ == "__main__":
+    PATH_HDF5_FEATURES = "/here.hdf5"
+    PATH_MODEL_SAVE = "model_trained.p"
+    df = pd.read_hdf(PATH_HDF5_FEATURES)
+
+    y = df["label"]
+    X = df[[f for f in df.columns if "time" not in f and "label" not in f]]
+    model = linear_model.LogisticRegression().fit(X, y)
+
+    with open(PATH_MODEL_SAVE, "wb") as fid:
+        pickle.dump(model, fid)


### PR DESCRIPTION
Added super simplistic training routine.

Points to check:
 - It might be not so visually clear to see the print line arguments, corresponding to MOVE or REST
 - Right now there is only a counter `training_samples` in features.py. So for e.g. 30s training, each class having 15s training time, we would need to calculate how many samples that correspond to, e.g. right now with 20ms: 15*(1/0.02s)
 - I terminate the `Features.run` function in case training is done with a simple `break`, I think that should work, but I'm not sure
 - I assume that .hdf5 saving with timeflux works. Otherwise we would need to collect the features independently, but I think this way should be fine, the `save` node just needs to be enabled