### PR TITLE
Add parallel batch processing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ dependencies = [
   "seaborn >= 0.11",
   "notebook",
   "ipython",
-  "pybispectra>=1.1.0"
+  "pybispectra>=1.1.0",
+  "joblib>=1.3.2"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
For offline data processing, added the possibility to process batches in parallel processes. This gave a nice 7x speed-up in total run time for my machine (Ryzen 5800H, 16 logical cores) with the following parameters:

NUM_CHANNELS = 5
NUM_DATA = 100000 # Random data points
sfreq = 1000  # Hz
feature_freq = 3  # Hz
n = 3 # Number of runs

Results (saving was disabled for this benchmark):
- Total time sequential: 52.11946733792623 seconds per run
- Total time parallel: 7.207633177439372 seconds per run

I also added a parameter to choose number of threads (although note, they are not technically threads, but actual processes because of how Python works) in case some computing power needs to be reserved on the machine running the code.

Idea: It might be possible to add multi-threading to live data processing too, but at the moment I am not familiar with that part of the program so I haven't determined viability yet.