### PR TITLE
Avoid use of Numpy nan statistics if possible

### DIFF
--- a/py_neuromodulation/nm_normalization.py
+++ b/py_neuromodulation/nm_normalization.py
@@ -3,8 +3,6 @@ from enum import Enum
 
 from sklearn import preprocessing
 import numpy as np
-
-
 class NORM_METHODS(Enum):
     MEAN = "mean"
     MEDIAN = "median"
@@ -138,6 +136,17 @@ class FeatureNormalizer:
 
         return data
 
+"""
+Functions to check for NaN's before deciding which Numpy function to call
+"""
+def nan_mean(data, axis):
+    return np.nanmean(data, axis=axis) if np.any(np.isnan(sum(data))) else np.mean(data, axis=axis)
+
+def nan_std(data, axis):
+    return np.nanstd(data, axis=axis) if np.any(np.isnan(sum(data))) else np.std(data, axis=axis)
+
+def nan_median(data, axis):
+    return np.nanmedian(data, axis=axis) if np.any(np.isnan(sum(data))) else np.median(data, axis=axis)
 
 def _normalize_and_clip(
     current: np.ndarray,
@@ -147,82 +156,80 @@ def _normalize_and_clip(
     description: str,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Normalize data."""
-    if method == NORM_METHODS.MEAN.value:
-        mean = np.nanmean(previous, axis=0)
-        current = (current - mean) / mean
-    elif method == NORM_METHODS.MEDIAN.value:
-        median = np.nanmedian(previous, axis=0)
-        current = (current - median) / median
-    elif method == NORM_METHODS.ZSCORE.value:
-        mean = np.nanmean(previous, axis=0)
-        current = (current - mean) / np.nanstd(previous, axis=0)
-    elif method == NORM_METHODS.ZSCORE_MEDIAN.value:
-        current = (current - np.nanmedian(previous, axis=0)) / np.nanstd(
-            previous, axis=0
-        )
-    # For the following methods we check for the shape of current
-    # when current is a 1D array, then it is the post-processing normalization,
-    # and we need to expand, and take the [0, :] component
-    # When current is a 2D array, then it is pre-processing normalization, and
-    # there's no need for expanding.
-    elif method == NORM_METHODS.QUANTILE.value:
-        if len(current.shape) == 1:
-            current = (
-                preprocessing.QuantileTransformer(n_quantiles=300)
-                .fit(np.nan_to_num(previous))
-                .transform(np.expand_dims(current, axis=0))[0, :]
-            )
-        else:
-            current = (
-                preprocessing.QuantileTransformer(n_quantiles=300)
-                .fit(np.nan_to_num(previous))
-                .transform(current)
-            )
-    elif method == NORM_METHODS.ROBUST.value:
-        if len(current.shape) == 1:
-            current = (
-                preprocessing.RobustScaler()
-                .fit(np.nan_to_num(previous))
-                .transform(np.expand_dims(current, axis=0))[0, :]
-            )
-        else:
-            current = (
-                preprocessing.RobustScaler()
-                .fit(np.nan_to_num(previous))
-                .transform(current)
-            )
+    match method:
+        case NORM_METHODS.MEAN.value:
+            mean = nan_mean(previous, axis=0)
+            current = (current - mean) / mean
+        case NORM_METHODS.MEDIAN.value:
+            median = nan_median(previous, axis=0)
+            current = (current - median) / median
+        case NORM_METHODS.ZSCORE.value:
+            current = (current - nan_mean(previous, axis=0)) / nan_std(previous, axis=0)
+        case NORM_METHODS.ZSCORE_MEDIAN.value:
+            current = (current - nan_median(previous, axis=0)) / nan_std(previous, axis=0)
+        # For the following methods we check for the shape of current
+        # when current is a 1D array, then it is the post-processing normalization,
+        # and we need to expand, and take the [0, :] component
+        # When current is a 2D array, then it is pre-processing normalization, and
+        # there's no need for expanding.
+        case NORM_METHODS.QUANTILE.value:
+            if len(current.shape) == 1:
+                current = (
+                    preprocessing.QuantileTransformer(n_quantiles=300)
+                    .fit(np.nan_to_num(previous))
+                    .transform(np.expand_dims(current, axis=0))[0, :]
+                )
+            else:
+                current = (
+                    preprocessing.QuantileTransformer(n_quantiles=300)
+                    .fit(np.nan_to_num(previous))
+                    .transform(current)
+                )
+        case NORM_METHODS.ROBUST.value:
+            if len(current.shape) == 1:
+                current = (
+                    preprocessing.RobustScaler()
+                    .fit(np.nan_to_num(previous))
+                    .transform(np.expand_dims(current, axis=0))[0, :]
+                )
+            else:
+                current = (
+                    preprocessing.RobustScaler()
+                    .fit(np.nan_to_num(previous))
+                    .transform(current)
+                )
 
-    elif method == NORM_METHODS.MINMAX.value:
-        if len(current.shape) == 1:
-            current = (
-                preprocessing.MinMaxScaler()
-                .fit(np.nan_to_num(previous))
-                .transform(np.expand_dims(current, axis=0))[0, :]
+        case NORM_METHODS.MINMAX.value:
+            if len(current.shape) == 1:
+                current = (
+                    preprocessing.MinMaxScaler()
+                    .fit(np.nan_to_num(previous))
+                    .transform(np.expand_dims(current, axis=0))[0, :]
+                )
+            else:
+                current = (
+                    preprocessing.MinMaxScaler()
+                    .fit(np.nan_to_num(previous))
+                    .transform(current)
+                )
+        case NORM_METHODS.POWER.value:
+            if len(current.shape) == 1:
+                current = (
+                    preprocessing.PowerTransformer()
+                    .fit(np.nan_to_num(previous))
+                    .transform(np.expand_dims(current, axis=0))[0, :]
+                )
+            else:
+                current = (
+                    preprocessing.PowerTransformer()
+                    .fit(np.nan_to_num(previous))
+                    .transform(current)
+                )
+        case _:
+            raise ValueError(
+                f"Only {[e.value for e in NORM_METHODS]} are supported as "
+                f"{description} normalization methods. Got {method}."
             )
-        else:
-            current = (
-                preprocessing.MinMaxScaler()
-                .fit(np.nan_to_num(previous))
-                .transform(current)
-            )
-    elif method == NORM_METHODS.POWER.value:
-        if len(current.shape) == 1:
-            current = (
-                preprocessing.PowerTransformer()
-                .fit(np.nan_to_num(previous))
-                .transform(np.expand_dims(current, axis=0))[0, :]
-            )
-        else:
-            current = (
-                preprocessing.PowerTransformer()
-                .fit(np.nan_to_num(previous))
-                .transform(current)
-            )
-    else:
-        raise ValueError(
-            f"Only {[e.value for e in NORM_METHODS]} are supported as "
-            f"{description} normalization methods. Got {method}."
-        )
 
     if clip:
         current = _clip(data=current, clip=clip)


### PR DESCRIPTION
Simple change to check for NaN's before using Numpy's nanmean, nanmedian and nanstd functions, and use their non-nanproof versions when possible. In my test is almost twice as fast, but of course this could be worse performance wise in the case that most/all of the batches contain NaNs, but the cost of checking for NaN's is low so it's probably faster in most cases, although this should be tested with real data containing NaN's.

I also tested different ways to check for NaN's and the fastest was given by [this StackOverflow comment ](https://stackoverflow.com/questions/6736590/fast-check-for-nan-in-numpy#comment68299587_6736970)

Minor change to add a match/case block to check normalization method, although the speed improvement is not relevant here it fits better imho.

Comparison of time spent on `_normalize_and_clip` function. Parameters are:
NUM_CHANNELS = 5
NUM_DATA = 100000
sfreq = 1000  # Hz
feature_freq = 3  # Hz
n = 3 # Repeats

- With Numpy nan functions:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2970    0.113    0.000   30.866    0.010 nm_normalization.py:141(_normalize_and_clip)
     2970    0.047    0.000   20.850    0.007 nanfunctions.py:1778(nanstd)
     2970    9.525    0.003   20.803    0.007 nanfunctions.py:1617(nanvar)
     5940    4.958    0.001   10.295    0.002 nanfunctions.py:68(_replace_nan)
     2970    0.406    0.000    9.605    0.003 nanfunctions.py:952(nanmean)
    14850    0.064    0.000    9.044    0.001 fromnumeric.py:2177(sum)
    17820    0.115    0.000    8.999    0.001 fromnumeric.py:71(_wrapreduction)
    20790    8.874    0.000    8.874    0.000 {method 'reduce' of 'numpy.ufunc' objects}
     8910    5.337    0.001    5.337    0.001 {built-in method numpy.array}
```

- Checking for NaN's first (here nan_std, nan_mean are my custom functions):
```
     ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2970    0.085    0.000   17.506    0.006 nm_normalization.py:153(_normalize_and_clip)
     2970    0.052    0.000   12.598    0.004 nm_normalization.py:147(nan_std)
     2970    0.015    0.000   10.342    0.003 fromnumeric.py:3513(std)
     2970    0.063    0.000   10.327    0.003 _methods.py:204(_std)
     2970    6.423    0.002   10.264    0.003 _methods.py:135(_var)
    14850    5.403    0.000    5.403    0.000 {method 'reduce' of 'numpy.ufunc' objects}
     5940    4.589    0.001    4.589    0.001 {built-in method builtins.sum}
     2970    0.069    0.000    4.475    0.002 nm_normalization.py:144(nan_mean)
     2970    0.014    0.000    1.876    0.001 fromnumeric.py:3385(mean)
     2970    0.091    0.000    1.862    0.001 _methods.py:101(_mean)
     2970    0.031    0.000    0.332    0.000 nm_normalization.py:242(_clip)
     2970    0.108    0.000    0.262    0.000 type_check.py:403(nan_to_num)
     5940    0.024    0.000    0.141    0.000 fromnumeric.py:2322(any)
     5940    0.047    0.000    0.117    0.000 fromnumeric.py:71(_wrapreduction)
```