### PR TITLE
Bursts feature performance improvement

### DIFF
--- a/py_neuromodulation/nm_bursts.py
+++ b/py_neuromodulation/nm_bursts.py
@@ -170,11 +170,11 @@ class Burst(nm_features_abc.Feature):
         burst_length = []
         burst_amplitude = []
 
-        burst_states = np.where(deriv==True)[0]
+        burst_time_points = np.where(deriv==True)[0]
 
-        for i in range(burst_states.size//2):
-            burst_length.append(burst_states[2 * i + 1] - burst_states[2 * i])
-            burst_amplitude.append(beta_averp_norm[burst_states[2 * i] : burst_states[2 * i + 1]])
+        for i in range(burst_time_points.size//2):
+            burst_length.append(burst_time_points[2 * i + 1] - burst_time_points[2 * i])
+            burst_amplitude.append(beta_averp_norm[burst_time_points[2 * i] : burst_time_points[2 * i + 1]])
 
         # the last burst length (in case isburst == True) is omitted,
         # since the true burst length cannot be estimated

--- a/py_neuromodulation/nm_bursts.py
+++ b/py_neuromodulation/nm_bursts.py
@@ -167,25 +167,18 @@ class Burst(nm_features_abc.Feature):
         bursts = np.zeros((beta_averp_norm.shape[0] + 1), dtype=bool)
         bursts[1:] = beta_averp_norm >= burst_thr
         deriv = np.diff(bursts)
-        isburst = False
         burst_length = []
         burst_amplitude = []
-        burst_start = 0
 
-        for index, burst_state in enumerate(deriv):
-            if burst_state == True:
-                if isburst == True:
-                    burst_length.append(index - burst_start)
-                    burst_amplitude.append(beta_averp_norm[burst_start:index])
+        burst_states = np.where(deriv==True)[0]
 
-                    isburst = False
-                else:
-                    burst_start = index
-                    isburst = True
+        for i in range(burst_states.size//2):
+            burst_length.append(burst_states[2 * i + 1] - burst_states[2 * i])
+            burst_amplitude.append(beta_averp_norm[burst_states[2 * i] : burst_states[2 * i + 1]])
 
         # the last burst length (in case isburst == True) is omitted,
         # since the true burst length cannot be estimated
-
         burst_length = np.array(burst_length) / sfreq
 
         return burst_amplitude, burst_length
+    


### PR DESCRIPTION
Small change to simplify the code of nm_bursts.py function `get_burst_amplitude_length`, to make it faster by removing the line
```Python
if burst_state == True:
```
which was responsible for most of the slowdown, maybe due to the CPU not being able to pipeline the computations due to the next value of the `burst_state` variable being impossible to predict. Pre-calculating burst indexes with 
```Python
burst_states = np.where(deriv==True)[0]
```
fixed the issue, and made the function about 3x faster.

Benchmark code:
```Python

NUM_CHANNELS = 5
NUM_DATA = 100000
sfreq = 1000 # Hz
feature_freq = 3 # Hz
n = 3 # Repeats

np.random.seed(0)

elapsed = 0
for i in range(n):
    data = np.random.random([NUM_CHANNELS, NUM_DATA])
    t = time.time()
    stream = nm.Stream(sfreq=sfreq, data=data, settings=settings, verbose=False)
    stream.run()
    elapsed += time.time() - t
print("Total time sequential:", elapsed/n, "seconds.")
```
- Before: Total time sequential: 67.5419061978658 seconds per run.
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2973    2.086    0.001   68.429    0.023 nm_bursts.py:97(calc_feature)
    44595   40.738    0.001   41.270    0.001 nm_bursts.py:162(get_burst_amplitude_length)
    44595    0.321    0.000   14.621    0.000 function_base.py:3992(percentile)
    44595    0.077    0.000   13.178    0.000 function_base.py:4547(_quantile_unchecked)
    44595    0.147    0.000   13.101    0.000 function_base.py:3763(_ureduce)
    44595    0.104    0.000   12.938    0.000 function_base.py:4696(_quantile_ureduce_func)
    44595    0.971    0.000   12.095    0.000 function_base.py:4764(_quantile)
```
- After: Total time sequential: 54.67773127555847 seconds per run.
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2973    1.769    0.001   26.469    0.009 nm_bursts.py:97(calc_feature)
    44595    0.266    0.000   13.430    0.000 function_base.py:3992(percentile)
    44595    0.062    0.000   12.169    0.000 function_base.py:4547(_quantile_unchecked)
    44595    0.118    0.000   12.107    0.000 function_base.py:3763(_ureduce)
    44595    0.083    0.000   11.973    0.000 function_base.py:4696(_quantile_ureduce_func)
    44595    0.814    0.000   11.366    0.000 function_base.py:4764(_quantile)
    44595    7.544    0.000    7.544    0.000 {method 'partition' of 'numpy.ndarray' objects}
```

Aside from this simple fix, I have a working branch to attempt to completely vectorize nm_bursts' calc_feature function, but so far attempts have been unsuccesful.

The biggest performance cost of the function is percentile calculation, so that would be the next thing to fix.