### PR TITLE
Sharpwaves performance fixes

### DIFF
--- a/py_neuromodulation/nm_sharpwaves.py
+++ b/py_neuromodulation/nm_sharpwaves.py
@@ -323,10 +323,16 @@ class SharpwaveAnalyzer(nm_features_abc.Feature):
 
             if self.sw_settings["sharpwave_features"]["rise_steepness"]: # left peak -> trough
                 # + 1 due to python syntax, s.t. the last element is included
-                self.rise_steepness = np.array([np.max(steepness[peak_idx_left[i] : troughs[i] + 1]) for i in range(trough_idx.size)])
+                self.rise_steepness = np.array([
+                    np.max(np.abs(steepness[peak_idx_left[i] : troughs[i] + 1]))
+                    for i in range(trough_idx.size)
+                ])
                 
             if self.sw_settings["sharpwave_features"]["decay_steepness"]: # trough -> right peak
-                self.decay_steepness = np.array([np.max(steepness[troughs[i] : peak_idx_right[i] + 1]) for i in range(trough_idx.size)])
+                self.decay_steepness = np.array([
+                    np.max(np.abs(steepness[troughs[i] : peak_idx_right[i] + 1]))
+                    for i in range(trough_idx.size)
+                ])
 
             if (self.sw_settings["sharpwave_features"]["rise_steepness"] and
                 self.sw_settings["sharpwave_features"]["decay_steepness"] and

--- a/py_neuromodulation/nm_sharpwaves.py
+++ b/py_neuromodulation/nm_sharpwaves.py
@@ -292,9 +292,7 @@ class SharpwaveAnalyzer(nm_features_abc.Feature):
         """ Calculate features (vectorized) """
 
         if self.sw_settings["sharpwave_features"]["interval"]:
-            self.interval = (np.pad(troughs, (0,1)) - np.pad(troughs, (1,0))) * (1000 / self.sfreq)
-            if self.interval.shape[0] > 1: self.interval = self.interval[:-1]
-            self.interval[0] = 0
+            self.interval = np.concatenate(([0], np.diff(troughs))) * (1000 / self.sfreq)
 
         if self.sw_settings["sharpwave_features"]["peak_left"]:
             self.peak_left = peak_left

--- a/py_neuromodulation/nm_sharpwaves.py
+++ b/py_neuromodulation/nm_sharpwaves.py
@@ -143,7 +143,7 @@ class SharpwaveAnalyzer(nm_features_abc.Feature):
                 if filter_name == "no_filter":
                     self.data_process_sw = data[ch_idx, :]
                 else:
-                    self.data_process_sw = signal.convolve(
+                    self.data_process_sw = signal.fftconvolve(
                         data[ch_idx, :], filter, mode="same"
                     )
 

--- a/py_neuromodulation/nm_sharpwaves.py
+++ b/py_neuromodulation/nm_sharpwaves.py
@@ -281,6 +281,9 @@ class SharpwaveAnalyzer(nm_features_abc.Feature):
 
         troughs = troughs[first_valid:last_valid + 1] # Remove non valid troughs
         
+        peak_idx_left = np.array(peak_idx_left, dtype=np.integer)
+        peak_idx_right = np.array(peak_idx_right, dtype=np.integer)
+
         peak_left = self.data_process_sw[peak_idx_left]
         peak_right = self.data_process_sw[peak_idx_right]
         trough_values = self.data_process_sw[troughs]
@@ -290,7 +293,7 @@ class SharpwaveAnalyzer(nm_features_abc.Feature):
         # self.troughs_idx.append(trough_idx)
          
         """ Calculate features (vectorized) """
-
+        
         if self.sw_settings["sharpwave_features"]["interval"]:
             self.interval = np.concatenate(([0], np.diff(troughs))) * (1000 / self.sfreq)
 

--- a/py_neuromodulation/nm_sharpwaves.py
+++ b/py_neuromodulation/nm_sharpwaves.py
@@ -257,21 +257,22 @@ class SharpwaveAnalyzer(nm_features_abc.Feature):
             distance=self.sw_settings["detect_troughs"]["distance_troughs_ms"],
         )[0]
 
+        right_peak_idx = 0
         for trough_idx in troughs:
-            try:
-                (
-                    peak_idx_left,
-                    peak_idx_right,
-                    peak_left,
-                    peak_right,
-                ) = self._get_peaks_around(
-                    trough_idx, peaks, self.data_process_sw
-                )
-            except NoValidTroughException:
-                # in this case there are no adjacent two peaks around this trough
-                # str(e) could print the exception error message
-                # print(str(e))
+            
+            while right_peak_idx < peaks.size and peaks[right_peak_idx] < trough_idx:
+                right_peak_idx += 1
+
+            if right_peak_idx - 1 < 0:
                 continue
+            peak_idx_left = peaks[right_peak_idx - 1]
+
+            if right_peak_idx >= peaks.size:
+                continue
+            peak_idx_right = peaks[right_peak_idx]
+
+            peak_left = self.data_process_sw[peak_idx_left]
+            peak_right = self.data_process_sw[peak_idx_right]
 
             trough = self.data_process_sw[trough_idx]
             self.trough.append(trough)

--- a/py_neuromodulation/nm_sharpwaves.py
+++ b/py_neuromodulation/nm_sharpwaves.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy import signal
 from mne.filter import create_filter
 from typing import Iterable
+import sys
 
 from py_neuromodulation import nm_features_abc
 
@@ -105,23 +106,12 @@ class SharpwaveAnalyzer(nm_features_abc.Feature):
         peak_right_val (np.ndarray): value of righ peak
         """
 
-        ind_greater = np.where(arr_ind_peaks > trough_ind)[0]
-        if ind_greater.shape[0] == 0:
-            raise NoValidTroughException("No valid trough")
-        val_ind_greater = arr_ind_peaks[ind_greater]
-        peak_right_idx = arr_ind_peaks[
-            ind_greater[np.argsort(val_ind_greater)[0]]
-        ]
+        try: peak_right_idx = arr_ind_peaks[arr_ind_peaks > trough_ind][0]
+        except IndexError: raise NoValidTroughException("No valid trough")
 
-        ind_smaller = np.where(arr_ind_peaks < trough_ind)[0]
-        if ind_smaller.shape[0] == 0:
-            raise NoValidTroughException("No valid trough")
-
-        val_ind_smaller = arr_ind_peaks[ind_smaller]
-        peak_left_idx = arr_ind_peaks[
-            ind_smaller[np.argsort(val_ind_smaller)[-1]]
-        ]
-
+        try: peak_left_idx  = arr_ind_peaks[arr_ind_peaks < trough_ind][-1]
+        except IndexError: raise NoValidTroughException("No valid trough")
+       
         return (
             peak_left_idx,
             peak_right_idx,


### PR DESCRIPTION
When running the profiler on an offline analysis _sharpwaves_ was, together with _bursts_, one of the more computationally costly features to calculate. I made some changes that brought the computation time for this feature down to 50%:

Commit 1 - Simplify `_get_peaks_around`: The profiler showed a very high amount of calls to `argsort` from the method `_get_peaks_around` and I realized that for each trough in the data, this function was being called and subsequently calling argsort twice. I worked out the logic of the function and realized that since `scipy.signal.find_peaks` is returning the peak indexes in order the calculation can be reduced to an array filtering operation which is much faster. 

Commit 2 - Single pass adjacent peak finding: Even with the previous change, it seemed to me that calling `_get_peaks_around` once per trough, and then doing a comparison on the whole list of indexes was not necessary, so I replaced the `_get_peaks_around` calls with a variable `right_peak_idx` which each loop it increases until it goes past the current trough, keeping track of the right adjacent peak to the current trough at each step of the loop. This makes it so that all the work `_get_peaks_around` was doing we get for free now.

Commit 3 - fftconvolve: Since `signal.convolve` was calling `signal.fftconvolve`  under-the-hood, I changed it to that, which removes the overhead of having to decide which method to use and makes the code more transparent in my opinion. Barely impacts performance.

-Before changes: 58.61098559697469 seconds per run.
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2973    1.638    0.001   60.456    0.020 nm_sharpwaves.py:133(calc_feature)
    59460   18.797    0.000   49.876    0.001 nm_sharpwaves.py:250(analyze_waveform)
  2719352   16.517    0.000   26.317    0.000 nm_sharpwaves.py:88(_get_peaks_around)
  5469224    2.191    0.000    9.698    0.000 fromnumeric.py:1025(argsort)
  5469224    2.105    0.000    7.507    0.000 fromnumeric.py:53(_wrapfunc)
    29730    0.320    0.000    5.782    0.000 _signaltools.py:1299(convolve)
    29730    0.128    0.000    4.895    0.000 _signaltools.py:557(fftconvolve)
  5469224    4.626    0.000    4.626    0.000 {method 'argsort' of 'numpy.ndarray' objects}
    29730    0.363    0.000    4.052    0.000 _signaltools.py:459(_freq_domain_conv)
   118920    0.552    0.000    3.784    0.000 _peak_finding.py:729(find_peaks)
```
-After commit 1: 53.140084981918335 seconds per run.
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2973    1.599    0.001   41.187    0.014 nm_sharpwaves.py:123(calc_feature)
    59460   16.981    0.000   30.919    0.001 nm_sharpwaves.py:240(analyze_waveform)
  2719352    9.412    0.000    9.412    0.000 nm_sharpwaves.py:89(_get_peaks_around)
    29730    0.309    0.000    5.646    0.000 _signaltools.py:1299(convolve)
    29730    0.124    0.000    4.802    0.000 _signaltools.py:557(fftconvolve)
    29730    0.355    0.000    3.993    0.000 _signaltools.py:459(_freq_domain_conv)
   118920    0.525    0.000    3.661    0.000 _peak_finding.py:729(find_peaks)
    89190    0.139    0.000    3.582    0.000 _backend.py:17(__ua_function__)
    59460    0.213    0.000    2.457    0.000 basic.py:203(r2cn)
```
- After commit 2: 48.184030532836914 seconds per run
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2973    1.528    0.001   31.175    0.010 nm_sharpwaves.py:123(calc_feature)
    59460   17.096    0.000   21.421    0.000 nm_sharpwaves.py:240(analyze_waveform)
    29730    0.284    0.000    5.319    0.000 _signaltools.py:1299(convolve)
    29730    0.117    0.000    4.545    0.000 _signaltools.py:557(fftconvolve)
    29730    0.328    0.000    3.797    0.000 _signaltools.py:459(_freq_domain_conv)
   118920    0.516    0.000    3.505    0.000 _peak_finding.py:729(find_peaks)
    89190    0.137    0.000    3.421    0.000 _backend.py:17(__ua_function__)
    59460    0.199    0.000    2.325    0.000 basic.py:203(r2cn)
   118920    0.608    0.000    1.840    0.000 {scipy.signal._peak_finding_utils._select_by_peak_distance}
   178380    0.169    0.000    1.374    0.000 fromnumeric.py:2692(max)
```

- After commit 3: 47.840235233306885 seconds per run.