### PR TITLE
Fix handling of dataframe input, issue #300

### DIFF
--- a/py_neuromodulation/nm_stream_offline.py
+++ b/py_neuromodulation/nm_stream_offline.py
@@ -88,9 +88,9 @@ class _OfflineStream(nm_stream_abc.PNStream):
             if not len(names_expected) == data.shape[0]:
                 raise ValueError(
                     "If data is passed as an array, the first dimension must"
-                    " match the number of channel names in `nm_channels`. Got:"
-                    f" Data columns: {data.shape[0]}, nm_channels.name:"
-                    f" {len(names_expected)}."
+                    " match the number of channel names in `nm_channels`.\n"
+                    f" Number of data channels (data.shape[0]): {data.shape[0]}\n"
+                    f" Length of nm_channels[\"name\"]: {len(names_expected)}."
                 )
             return data
         names_data = data.columns.to_list()
@@ -100,10 +100,11 @@ class _OfflineStream(nm_stream_abc.PNStream):
         ):
             raise ValueError(
                 "If data is passed as a DataFrame, the"
-                "columns must match the channel names in `nm_channels`. Got:"
-                f"Data columns: {names_data}, nm_channels.name: {names_data}."
+                "column names must match the channel names in `nm_channels`.\n"
+                f"Input dataframe column names: {names_data}\n"
+                f"Expected (from nm_channels[\"name\"]): : {names_expected}."
             )
-        return data.to_numpy()
+        return data.to_numpy().transpose()
 
     def _check_settings_for_parallel(self):
         """Check specified settings and raise error if parallel processing is not possible.


### PR DESCRIPTION
This should fix the problem in #300, by returning the transposed version of the data from _OfflineStream._handle_data when the input is given in the form of a DataFrame. I also fixed the Error message that caused the confusion in the first place.

Additionally, this raises the issue of having 2 different expected data input layouts:
- For numpy arrays: (n_channels, n_timepoints) 
- For pandas dataframes: (n_timepoints, n_channels)
This is AFAIK not very well explained in the documentation.

Changing the expected dimensions of the np.array is most likely impossible since it would break compatibility. But also changing the dimensionality of dataframes is probably also not a good idea since rows for datapoints and columns for features is the standard way people organize data.

So I have settled for this solution for now.