### PR TITLE
Improve Github actions testing workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,34 +20,36 @@ on:
       - '*.txt'
 jobs:
   tests:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.platform.name }} Python ${{ matrix.python }}
+    runs-on: ${{ matrix.platform.os }}
     env:
       APPDATA: DefaultNonExistingPath 
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - {name: 3.10 Mac, python: '3.10', os: macos-latest, tox: py310}
-          - {name: 3.10 Linux, python: '3.10', os: ubuntu-latest, tox: py310}
+        platform:
+          - os: ubuntu-latest
+            name: Linux
+            activate_env: . .venv/bin/activate
+          - os: macos-latest
+            name: MacOS
+            activate_env: . .venv/bin/activate
+          - os: windows-latest
+            name: Windows
+            activate_env: .venv\Scripts\activate
+        python:
+          - '3.10'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - name: Set up Python with uv
+        uses: drivendataorg/setup-python-uv-action@v1
         with:
           python-version: ${{ matrix.python }}
-      - name: update pip
-        run: |
-          python -m pip install -U pip
-      - name: get pip cache dir
-        id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
-      - name: cache pip
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: pip|${{ runner.os }}|${{ matrix.python }}|${{ hashFiles('requirements/*.txt') }}
-          restore-keys: pip|${{ runner.os }}|${{ matrix.python }}
-      - run: pip install tox
-        env:
-          APPDATA: DefaultNonExistingPath 
-      - run: tox -e ${{ matrix.tox }}
+          cache: packages
+          cache-dependency-path: pyproject.toml
+      - name: Install dependencies
+        run: uv pip install .
+      - name: Install pytest
+        run: uv pip install pytest pytest-xdist
+      - name: Run tests
+        run: pytest -n auto tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,21 +22,16 @@ jobs:
   tests:
     name: ${{ matrix.platform.name }} Python ${{ matrix.python }}
     runs-on: ${{ matrix.platform.os }}
-    env:
-      APPDATA: DefaultNonExistingPath 
     strategy:
       fail-fast: false
       matrix:
         platform:
           - os: ubuntu-latest
             name: Linux
-            activate_env: . .venv/bin/activate
           - os: macos-latest
             name: MacOS
-            activate_env: . .venv/bin/activate
           - os: windows-latest
             name: Windows
-            activate_env: .venv\Scripts\activate
         python:
           - '3.10'
     steps:
@@ -50,6 +45,6 @@ jobs:
       - name: Install dependencies
         run: uv pip install .
       - name: Install pytest
-        run: uv pip install pytest pytest-xdist
+        run: uv pip install pytest pytest-xdist pytest-sugar
       - name: Run tests
         run: pytest -n auto tests/

--- a/.gitignore
+++ b/.gitignore
@@ -160,16 +160,12 @@ sub/
 
 py_neuromodulation/data/derivatives/*
 
-requirements.lock
-requirements-dev.lock
-
 .python-version
 
 py_neuromodulation/ConnectivityDecoding/connectome_folder/*
 
 plot_0_first_demo.py
+plot_1_example_BIDS.py
 
 requirements.lock
 requirements-dev.lock
-
-plot_1_example_BIDS.py

--- a/README.rst
+++ b/README.rst
@@ -40,21 +40,6 @@ py_neuromodulation requires at least python 3.10. For installation you can use p
 
     pip install py-neuromodulation
 
-
-We recommend however installing the package using `rye <https://rye-up.com/guide/installation/>`_:
-
-.. code-block::
-
-    git clone https://github.com/neuromodulation/py_neuromodulation.git
-    rye pin 3.11
-    rye sync
-
-And then activating the virtual environment e.g. in Windows using:
-
-.. code-block::
-
-    .\.venv\Scripts\activate
-
 Alternatively you can also install the package in a conda environment:
 
 .. code-block::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
     "black>=24.2.0",
     "pytest>=8.0.2",
     "pytest-cov",
+    "pytest-sugar",
     "notebook",
 ]
 
@@ -81,22 +82,7 @@ docs = [
 
 [tool.rye]
 dev-dependencies = [
-    "black>=24.2.0",
-    "pytest>=8.0.2",
-    "pytest-cov",
-    "notebook",
     "py-neuromodulation[dev]",
-    "nbsphinx",
-    "sphinx",
-    "pandoc",
-    "recommonmark",
-    "sphinx",
-    "numpydoc",
-    "sphinx-gallery",
-    "nbsphinx_link",
-    "pydata-sphinx-theme",
-    "pypandoc",
-    "sphinx_togglebutton",
 ]
 
 [project.urls]
@@ -116,23 +102,3 @@ exclude = [
   "py_neuromodulation/data/derivatives",
   "py_neuromodulation/ConnectivityDecoding/connectome_folder",
 ]
-
-[tool.tox]
-legacy_tox_ini = """
-  [tox]
-  env_list =
-    py3{10, 11}
-  
-  skip_missing_interpreters = true
-  isolated_build = true
-
-
-  [testenv]
-  description = install pytest in a virtual environment and invoke it on the tests folder
-  deps =
-      pytest>=7
-      pytest-sugar
-  commands = pytest tests {posargs}
-"""
-
-# check https://stackoverflow.com/a/40831237/5060208 for adding posargs to pytest


### PR DESCRIPTION
So, as I mentioned in issue #310 I wanted to see if Rye could speed up setting up the testing environment for Github actions automated testing.

In the end I made several changes:
- Rye was not the adequate tool, is more a development environment manager than a package installer, so I used uv (https://astral.sh/blog/uv) instead, which is created by the same developers and it's what Rye uses under the hood.
- The Github action for setting up uv (https://github.com/drivendataorg/setup-python-uv-action/) also handles dependency caching which is a cool feature, although even without the cache the whole process if very fast (it's about 7 seconds to download and install everything)
- I got rid of Tox since it wasn't doing really anything for us at the moment. Right now the only real work it was doing was installing pytest, and that can be easily handled in the Github action workflow.
- I added pytest-xdist which multithreads the tests, basically running 4 cores at the same time and using them to run tests in parallel.

Overall, the testing time in Linux went from 2m20s to 1m10s, so that's half the time if my math is correct.

PS. Oh, and forgot to add that tests run in Windows now as well

PS2. With dependencies already cached, 59s on Linux!