### PR TITLE
Minor changes on top of mne_lsl merge

### DIFF
--- a/py_neuromodulation/nm_run_analysis.py
+++ b/py_neuromodulation/nm_run_analysis.py
@@ -270,10 +270,6 @@ class DataProcessor:
             Features calculated from current data
         """
         start_time = time()
-
-        if isinstance(data, tuple):
-            print(f"Data shape: {data[0].shape}")
-            data = np.array(data[1])
             
         nan_channels = np.isnan(data).any(axis=1)
 

--- a/tests/test_lsl_stream.py
+++ b/tests/test_lsl_stream.py
@@ -73,7 +73,7 @@ def test_offline_lsl():
     settings = nm_settings.get_default_settings()
     settings = nm_settings.set_settings_fast_compute(settings)
 
-    player = nm_generator.LSLOfflinePlayer(f_name = f_name, settings = settings)
+    player = nm_generator.LSLOfflinePlayer(f_name = f_name)
 
     def get_example_stream() -> nm_stream_abc.NMStream:
 


### PR DESCRIPTION
Hi @timonmerk, I made some changes on top of the recent LSL merge. Summary:

- Remove settings parameter from LSLOfflinePlayer since it's not used, as the sampling frequency  is passed in another parameter
- Defer LSLStream imports
- Fix a typing error
- Remove a couple variables
- Changed a couple errors for warnings:
    - If both a filename and a data array was passed to LSLOfflinePlayer, it would throw an error. I changed it to a warning and defaulted to using the file as data source.
    - If _GenericStream was reading from an LSLStream with different frequency that the one that was passed it would  throw an Exception, instead I think we can warn the user and default to the LSLStream frequency.

It's in general problematic to have 2 sources of truth like in the case of GenericStream getting an sfreq value from the user and one from the stream. It's also quite annoying that Python does not support overloaded constructors like C++. Maybe when I'm done with the Settings I will also incorporate Pydantic into the stream classes to handle this better.