### PR TITLE
Generate results directly from feature_dict instead of pd.Series

### DIFF
--- a/examples/plot_0_first_demo.py
+++ b/examples/plot_0_first_demo.py
@@ -155,7 +155,7 @@ features = stream.run(data)
 # There is a lot of output, which we could omit by verbose being False, but let's have a look what was being computed.
 # We will therefore use the :class:`~nm_analysis` class to showcase some functions. For multi-run -or subject analysis we will pass here the feature_file "sub" as default directory:
 
-analyzer = nm_analysis.Feature_Reader(
+analyzer = nm_analysis.FeatureReader(
     feature_dir=stream.PATH_OUT, feature_file=stream.PATH_OUT_folder_name
 )
 

--- a/examples/plot_1_example_BIDS.py
+++ b/examples/plot_1_example_BIDS.py
@@ -132,7 +132,7 @@ features = stream.run(
 # The obtained performances can now be read and visualized using the :class:`nm_analysis.Feature_Reader`.
 
 # initialize analyzer
-feature_reader = nm_analysis.Feature_Reader(
+feature_reader = nm_analysis.FeatureReader(
     feature_dir=PATH_OUT,
     feature_file=RUN_NAME,
 )

--- a/examples/plot_2_example_add_feature.py
+++ b/examples/plot_2_example_add_feature.py
@@ -45,9 +45,9 @@ class NewFeature(NMFeature):
 newFeature = NewFeature(
     stream.settings, list(stream.nm_channels["name"]), stream.sfreq
 )
-stream.run_analysis.features.features.append(newFeature)
+stream.data_processor.features.features.append(newFeature)
 
-features = stream.run_analysis.process(data)
+features = stream.data_processor.process(data)
 feature_name = f"new_feature_{stream.nm_channels['name'][0]}"
 
 print(f"{feature_name}: {features[feature_name]}")

--- a/examples/plot_3_example_sharpwave_analysis.py
+++ b/examples/plot_3_example_sharpwave_analysis.py
@@ -94,7 +94,7 @@ stream = nm.Stream(
     coord_names=coord_names,
     verbose=False,
 )
-sw_analyzer = stream.run_analysis.features.features[1]
+sw_analyzer = stream.data_processor.features.features[1]
 
 # %%
 # The plotted example time series, visualized on a short time scale, shows the relation of identified peaks, troughs, and estimated features:

--- a/examples/plot_4_example_gridPointProjection.py
+++ b/examples/plot_4_example_gridPointProjection.py
@@ -94,7 +94,7 @@ features = stream.run(
 # From nm_analysis.py, we use the :class:~`nm_analysis.FeatureReader` class to load the data.
 
 # init analyzer
-feature_reader = nm_analysis.Feature_Reader(
+feature_reader = nm_analysis.FeatureReader(
     feature_dir=PATH_OUT, feature_file=RUN_NAME
 )
 

--- a/examples/plot_6_real_time_demo.py
+++ b/examples/plot_6_real_time_demo.py
@@ -74,7 +74,7 @@ stream = nm.Stream(
     settings=get_fast_compute_settings(),
 )
 print(
-    f"{np.round(timeit.timeit(lambda: stream.run_analysis.process(data), number=100)/100, 3)} s"
+    f"{np.round(timeit.timeit(lambda: stream.data_processor.process(data), number=100)/100, 3)} s"
 )
 
 print("Computation time for 6 ECoG channels: ")
@@ -87,7 +87,7 @@ stream = nm.Stream(
     settings=get_fast_compute_settings(),
 )
 print(
-    f"{np.round(timeit.timeit(lambda: stream.run_analysis.process(data), number=100)/100, 3)} s"
+    f"{np.round(timeit.timeit(lambda: stream.data_processor.process(data), number=100)/100, 3)} s"
 )
 
 print(
@@ -99,7 +99,7 @@ stream = nm.Stream(
     sfreq=1000, data=data, sampling_rate_features_hz=10, verbose=False
 )
 print(
-    f"{np.round(timeit.timeit(lambda: stream.run_analysis.process(data), number=10)/10, 3)} s"
+    f"{np.round(timeit.timeit(lambda: stream.data_processor.process(data), number=10)/10, 3)} s"
 )
 
 

--- a/examples/plot_7_lsl_example.py
+++ b/examples/plot_7_lsl_example.py
@@ -120,7 +120,7 @@ plt.plot(features["time"], features["MOV_RIGHT"])
 # Note that the path was here adapted to be documentation build compliant.
 # %%
 
-feature_reader = nm_analysis.Feature_Reader(feature_dir=PATH_OUT, feature_file=RUN_NAME)
+feature_reader = nm_analysis.FeatureReader(feature_dir=PATH_OUT, feature_file=RUN_NAME)
 feature_reader.label_name = "MOV_RIGHT"
 feature_reader.label = feature_reader.feature_arr["MOV_RIGHT"]
 

--- a/py_neuromodulation/nm_analysis.py
+++ b/py_neuromodulation/nm_analysis.py
@@ -22,7 +22,7 @@ target_filter_str = {
 features_reverse_order_plotting = {"stft", "fft", "bandpass"}
 
 
-class Feature_Reader:
+class FeatureReader:
     def __init__(
         self, feature_dir: str, feature_file: str = "", binarize_label: bool = True
     ) -> None:

--- a/py_neuromodulation/nm_projection.py
+++ b/py_neuromodulation/nm_projection.py
@@ -289,14 +289,26 @@ class Projection:
         if not self.initialized:
             self.init_projection_run(feature_dict)
 
+        print([idx_ch for idx_ch in self.idx_chs_ecog])
+
         dat_cortex = (
-            np.array([feature_dict[idx_ch] for idx_ch in self.idx_chs_ecog])
+            np.array(
+                [
+                    np.array([feature_dict[ch] for ch in ch_names])
+                    for ch_names in self.names_chs_ecog
+                ]
+            )
             if self.project_cortex
             else None
         )
 
         dat_subcortex = (
-            np.array([feature_dict[idx_ch] for idx_ch in self.idx_chs_lfp])
+            np.array(
+                [
+                    np.array([feature_dict[ch] for ch in ch_names])
+                    for ch_names in self.names_chs_lfp
+                ]
+            )
             if self.project_subcortex
             else None
         )

--- a/py_neuromodulation/nm_projection.py
+++ b/py_neuromodulation/nm_projection.py
@@ -289,8 +289,6 @@ class Projection:
         if not self.initialized:
             self.init_projection_run(feature_dict)
 
-        print([idx_ch for idx_ch in self.idx_chs_ecog])
-
         dat_cortex = (
             np.array(
                 [

--- a/py_neuromodulation/nm_run_analysis.py
+++ b/py_neuromodulation/nm_run_analysis.py
@@ -1,8 +1,6 @@
 """This module contains the class to process a given batch of data."""
 
 from time import time
-from typing import Protocol
-
 import numpy as np
 import pandas as pd
 
@@ -12,21 +10,6 @@ from py_neuromodulation.nm_features import Features
 from py_neuromodulation.nm_preprocessing import NMPreprocessors
 from py_neuromodulation.nm_normalization import FeatureNormalizer
 from py_neuromodulation.nm_projection import Projection
-
-
-class Preprocessor(Protocol):
-    def process(self, data: np.ndarray) -> np.ndarray: ...
-
-    def test_settings(self, settings: dict): ...
-
-
-_PREPROCESSING_CONSTRUCTORS = [
-    "raw_resampling",
-    "notch_filter",
-    "re_referencing",
-    "raw_normalization",
-    "preprocessing_filter",
-]
 
 
 class DataProcessor:
@@ -256,7 +239,7 @@ class DataProcessor:
             coord_list=coord_list,  # type: ignore # None case handled above
         )
 
-    def process(self, data: np.ndarray) -> pd.Series:
+    def process(self, data: np.ndarray) -> dict[str, float]:
         """Given a new data batch, calculate and return features.
 
         Parameters
@@ -290,25 +273,25 @@ class DataProcessor:
                 for idx, key in enumerate(features_dict.keys())
             }
 
-        features_current = pd.Series(
-            data=list(features_dict.values()),
-            index=list(features_dict.keys()),
-            dtype=np.float64,
-        )
+        # features_current = pd.DataFrame(
+        #     data=list(features_dict.values()),
+        #     index=list(features_dict.keys()),
+        #     dtype=np.float64,
+        # )
 
         # project features to grid
-        if self.projection:
-            features_current = self.projection.project_features(features_current)
+        # if self.projection:
+        #     features_current = self.projection.project_features(features_current)
 
         # check for all features, where the channel had a NaN, that the feature is also put to NaN
-        if nan_channels.sum() > 0:
-            for ch in list(np.array(self.ch_names_used)[nan_channels]):
-                features_current.loc[features_current.index.str.contains(ch)] = np.nan
+        # if nan_channels.sum() > 0:
+        #     for ch in list(np.array(self.ch_names_used)[nan_channels]):
+        #         features_current.loc[features_current.index.str.contains(ch)] = np.nan
 
         if self.verbose:
             logger.info("Last batch took: %.2f seconds", time() - start_time)
 
-        return features_current
+        return features_dict
 
     def save_sidecar(
         self,

--- a/py_neuromodulation/nm_run_analysis.py
+++ b/py_neuromodulation/nm_run_analysis.py
@@ -273,20 +273,21 @@ class DataProcessor:
                 for idx, key in enumerate(features_dict.keys())
             }
 
-        # features_current = pd.DataFrame(
-        #     data=list(features_dict.values()),
-        #     index=list(features_dict.keys()),
-        #     dtype=np.float64,
-        # )
-
         # project features to grid
-        # if self.projection:
-        #     features_current = self.projection.project_features(features_current)
+        if self.projection:
+            self.projection.project_features(features_dict)
 
         # check for all features, where the channel had a NaN, that the feature is also put to NaN
-        # if nan_channels.sum() > 0:
-        #     for ch in list(np.array(self.ch_names_used)[nan_channels]):
-        #         features_current.loc[features_current.index.str.contains(ch)] = np.nan
+        if nan_channels.sum() > 0:
+            # TONI: no need to do this if we store both old and new names for the channels
+            new_nan_channels = []
+            for ch in list(np.array(self.ch_names_used)[nan_channels]):
+                for key in features_dict.keys():
+                    if ch in key:
+                        new_nan_channels.append(key)
+                
+            for ch in new_nan_channels:
+                features_dict[ch] = np.nan
 
         if self.verbose:
             logger.info("Last batch took: %.2f seconds", time() - start_time)

--- a/py_neuromodulation/nm_stream_abc.py
+++ b/py_neuromodulation/nm_stream_abc.py
@@ -67,7 +67,7 @@ class NMStream(ABC):
         self.projection = None
         self.model = None
 
-        self.run_analysis = DataProcessor(
+        self.data_processor = DataProcessor(
             sfreq=self.sfreq,
             settings=self.settings,
             nm_channels=self.nm_channels,
@@ -84,7 +84,7 @@ class NMStream(ABC):
         This might be handy in case the nm_channels or nm_settings changed
         """
 
-        self.run_analysis = DataProcessor(
+        self.data_processor = DataProcessor(
             sfreq=self.sfreq,
             settings=self.settings,
             nm_channels=self.nm_channels,
@@ -173,13 +173,13 @@ class NMStream(ABC):
         nm_IO.save_features(feature_arr, out_path_root, folder_name)
 
     def save_nm_channels(self, out_path_root: _PathLike, folder_name: str) -> None:
-        self.run_analysis.save_nm_channels(out_path_root, folder_name)
+        self.data_processor.save_nm_channels(out_path_root, folder_name)
 
     def save_settings(self, out_path_root: _PathLike, folder_name: str) -> None:
-        self.run_analysis.save_settings(out_path_root, folder_name)
+        self.data_processor.save_settings(out_path_root, folder_name)
 
     def save_sidecar(self, out_path_root: _PathLike, folder_name: str) -> None:
         """Save sidecar incduing fs, coords, sess_right to
         out_path_root and subfolder 'folder_name'"""
         additional_args = {"sess_right": self.sess_right}
-        self.run_analysis.save_sidecar(out_path_root, folder_name, additional_args)
+        self.data_processor.save_sidecar(out_path_root, folder_name, additional_args)

--- a/py_neuromodulation/nm_stream_offline.py
+++ b/py_neuromodulation/nm_stream_offline.py
@@ -180,7 +180,7 @@ class _GenericStream(NMStream):
 
         else:
             l_features: list[dict] = []
-            cnt_samples: int = int(offset_start)
+            cnt_samples = offset_start
 
             while True:
                 next_item = next(generator, None)
@@ -202,7 +202,7 @@ class _GenericStream(NMStream):
 
                 cnt_samples += sample_add
 
-        feature_df = pd.DataFrame.from_records(l_features)
+        feature_df = pd.DataFrame.from_records(l_features).astype(np.float64)
 
         self.save_after_stream(out_path_root, folder_name, feature_df)
 

--- a/py_neuromodulation/nm_stream_offline.py
+++ b/py_neuromodulation/nm_stream_offline.py
@@ -17,7 +17,7 @@ class _GenericStream(NMStream):
     nm_stream_abc : nm_stream_abc.NMStream
     """
 
-    def _add_target(self, feature_series: pd.Series, data: np.ndarray) -> pd.Series:
+    def _add_target(self, feature_dict: dict, data: np.ndarray) -> None:
         """Add target channels to feature series.
 
         Parameters
@@ -43,21 +43,19 @@ class _GenericStream(NMStream):
                 self.target_idx_initialized = True
 
             for target_idx, target_name in zip(self.target_indexes, self.target_names):
-                feature_series[target_name] = data[target_idx, -1]
-        return feature_series
+                feature_dict[target_name] = data[target_idx, -1]
 
-    def _add_timestamp(self, feature_series: pd.Series, cnt_samples: int) -> pd.Series:
+    def _add_timestamp(self, feature_dict: dict, cnt_samples: int) -> None:
         """Add time stamp in ms.
 
-        Due to normalization run_analysis needs to keep track of the counted
+        Due to normalization DataProcessor needs to keep track of the counted
         samples. These are accessed here for time conversion.
         """
-        feature_series["time"] = cnt_samples * 1000 / self.sfreq
+        timestamp = cnt_samples * 1000 / self.sfreq
+        feature_dict["time"] = timestamp
 
         if self.verbose:
-            logger.info("%.2f seconds of data processed", feature_series["time"] / 1000)
-
-        return feature_series
+            logger.info("%.2f seconds of data processed", timestamp / 1000)
 
     def _handle_data(self, data: np.ndarray | pd.DataFrame) -> np.ndarray:
         names_expected = self.nm_channels["name"].to_list()
@@ -71,6 +69,7 @@ class _GenericStream(NMStream):
                     f' Length of nm_channels["name"]: {len(names_expected)}.'
                 )
             return data
+
         names_data = data.columns.to_list()
         if not (
             len(names_expected) == len(names_data)
@@ -108,12 +107,10 @@ class _GenericStream(NMStream):
         # if isinstance(data_batch, tuple):
         #     data_batch = np.array(data_batch[1])
 
-        feature_series = self.run_analysis.process(data_batch[1].astype(np.float64))
-        feature_series = self._add_timestamp(feature_series, cnt_samples)
-        feature_series = self._add_target(
-            feature_series=feature_series, data=data_batch[1]
-        )
-        return feature_series
+        feature_dict = self.data_processor.process(data_batch[1].astype(np.float64))
+        self._add_timestamp(feature_dict, cnt_samples)
+        self._add_target(feature_dict, data_batch[1])
+        return feature_dict
 
     def _run(
         self,
@@ -126,7 +123,6 @@ class _GenericStream(NMStream):
         parallel: bool = False,
         n_jobs: int = -2,
     ) -> pd.DataFrame:
-
         from py_neuromodulation.nm_generator import raw_data_generator
 
         if not is_stream_lsl:
@@ -156,25 +152,22 @@ class _GenericStream(NMStream):
                 )
                 logger.warning(error_msg)
                 self.sfreq = self.lsl_stream.stream.sinfo.sfreq
-            
+
             generator = self.lsl_stream.get_next_batch()
 
-        sample_add = self.sfreq / self.run_analysis.sfreq_features
+        sample_add = self.sfreq / self.data_processor.sfreq_features
 
         offset_time = self.settings["segment_length_features_ms"]
         # offset_start = np.ceil(offset_time / 1000 * self.sfreq).astype(int)
         offset_start = offset_time / 1000 * self.sfreq
 
         if parallel:
-
             from joblib import Parallel, delayed
             from itertools import count
 
             # parallel processing can not be utilized if a LSL stream is used
             if is_stream_lsl:
-                error_msg = (
-                    "Parallel processing is not possible with LSL stream."
-                )
+                error_msg = "Parallel processing is not possible with LSL stream."
                 logger.error(error_msg)
                 raise ValueError(error_msg)
 
@@ -186,8 +179,8 @@ class _GenericStream(NMStream):
             )
 
         else:
-            l_features: list[pd.Series] = []
-            cnt_samples = offset_start
+            l_features: list[dict] = []
+            cnt_samples: int = int(offset_start)
 
             while True:
                 next_item = next(generator, None)
@@ -199,22 +192,17 @@ class _GenericStream(NMStream):
 
                 if data_batch is None:
                     break
-                feature_series = self.run_analysis.process(
+                feature_dict = self.data_processor.process(
                     data_batch.astype(np.float64)
                 )
+                self._add_timestamp(feature_dict, cnt_samples)
+                self._add_target(feature_dict, data_batch)
 
-                feature_series = self._add_timestamp(
-                   feature_series, cnt_samples  
-                )
-
-                feature_series = self._add_target(
-                    feature_series=feature_series, data=data_batch
-                )
-
-                l_features.append(feature_series)
+                l_features.append(feature_dict)
 
                 cnt_samples += sample_add
-        feature_df = pd.DataFrame(l_features)
+
+        feature_df = pd.DataFrame.from_records(l_features)
 
         self.save_after_stream(out_path_root, folder_name, feature_df)
 

--- a/tests/test_fooof.py
+++ b/tests/test_fooof.py
@@ -6,7 +6,7 @@ def test_fooof_features(setup_default_stream_fast_compute):
 
     generator = nm_generator.raw_data_generator(data, stream.settings, stream.sfreq)
     _, data_batch = next(generator, None)
-    feature_series = stream.run_analysis.process(data_batch)
+    feature_series = stream.data_processor.process(data_batch)
     # since the settings can define searching for "max_n_peaks" peaks
     # there can be None's in the feature_series
     # with a non successful fit, aperiodic features can also be None


### PR DESCRIPTION
While I was working on bursts vectorization, I was checking the profiling results and I noticed an unusual amount of time being spent in `pd.Series.__init__` and also in `_add_timestamp`. In total, they accounted for 6 to 7% of the running time.
 - `pd.Series.__init__`: 2.5%
 - `_add_timestamp`: 3.8% 

I realized this was due to the transformation of the dictionary of feature results `feature_dict` to a pd.Series `feature_series`, as well as the modification of a pd.Series instead of a `dict` which comes at a much greater cost due to Pandas overhead, possibly having to move the entire series around in memory, etc. This was done, I imagine, to facilitate some of the computations that were done on that series, mainly the cortex/subcortex projection. But paying a 7% of the running time is too high a cost imho. 

Also, using a pd.Series to store a row works in opposition to Pandas logic, which actually stores one Series per column, not per row. So what I did was remove the intermediate transformation of `feature_dict` to `feature_series` and instead of the `Stream.run` function generating a list of pd.Series, it generates a list of feature_dict, then it transforms the dict into the final result dataframe with pd.DataFrame.from_records()

To make this work, I had to make some very small syntax changes, but the logic of everything is the same, just using `dict` instead of `pd.Series`. Of course now `Projection.project()` is a bit slower than before after the very naif syntax conversion (there might be a way to speed it up) but overall shaving off a 7% of the runtime basically for free compensates for it. 

Also, I think removing the reliance on Pandas when it comes to handling data during processing is a positive, as it comes with too much overhead. In fact, I'm a proponent of even ditching `dict` and going `np.array` all the way, but getting rid of pd.df is a good step in that direction.

So, in conclusion:
- No pd.Series, just `dict` until the final dataframe generation.
- 6-7% of the running time saved when cortical projection not enabled.
- Dependency on Pandas for data handling reduced.