### PR TITLE
Optimize Hjorth and LineLength calculation

### DIFF
--- a/py_neuromodulation/nm_hjorth_raw.py
+++ b/py_neuromodulation/nm_hjorth_raw.py
@@ -1,9 +1,8 @@
 """
-Reference: Oh, S. H., Lee, Y. R., & Kim, H. N. (2014).
-            A novel EEG feature extraction method using Hjorth parameter.
-            International Journal of Electronics and Electrical Engineering, 2(2), 106-110.
-http://cspl.ee.pusan.ac.kr/sites/cspl/download/internation_c/ICAEE2014_02_OSH.pdf
-
+Reference:  B Hjorth
+            EEG analysis based on time domain properties
+            Electroencephalogr Clin Neurophysiol. 1970 Sep;29(3):306-10.
+            DOI: 10.1016/0013-4694(70)90143-4
 """
 
 import numpy as np

--- a/py_neuromodulation/nm_hjorth_raw.py
+++ b/py_neuromodulation/nm_hjorth_raw.py
@@ -1,3 +1,11 @@
+"""
+Reference: Oh, S. H., Lee, Y. R., & Kim, H. N. (2014).
+            A novel EEG feature extraction method using Hjorth parameter.
+            International Journal of Electronics and Electrical Engineering, 2(2), 106-110.
+http://cspl.ee.pusan.ac.kr/sites/cspl/download/internation_c/ICAEE2014_02_OSH.pdf
+
+"""
+
 import numpy as np
 from collections.abc import Iterable
 
@@ -6,23 +14,27 @@ from py_neuromodulation.nm_settings import NMSettings
 
 
 class Hjorth(NMFeature):
-    def __init__(self, settings: NMSettings, ch_names: Iterable[str], sfreq: float) -> None:
+    def __init__(
+        self, settings: NMSettings, ch_names: Iterable[str], sfreq: float
+    ) -> None:
         self.ch_names = ch_names
 
     def calc_feature(self, data: np.ndarray, features_compute: dict) -> dict:
-        for ch_idx, ch_name in enumerate(self.ch_names):
-            features_compute["_".join([ch_name, "RawHjorth_Activity"])] = np.nan_to_num(
-                np.var(data[ch_idx, :])
-            )
-            deriv_variance = np.nan_to_num(np.var(np.diff(data[ch_idx, :])))
-            mobility = np.nan_to_num(np.sqrt(deriv_variance / np.var(data[ch_idx, :])))
-            features_compute["_".join([ch_name, "RawHjorth_Mobility"])] = mobility
+        var = np.var(data, axis=-1)
+        deriv1 = np.diff(data, axis=-1)
+        deriv2 = np.diff(deriv1, axis=-1)
+        deriv1_var = np.var(deriv1, axis=-1)
+        deriv2_var = np.var(deriv2, axis=-1)
+        deriv1_mobility = np.sqrt(deriv2_var / deriv1_var)
 
-            dat_deriv_2_var = np.nan_to_num(np.var(np.diff(np.diff(data[ch_idx, :]))))
-            deriv_mobility = np.nan_to_num(np.sqrt(dat_deriv_2_var / deriv_variance))
-            features_compute["_".join([ch_name, "RawHjorth_Complexity"])] = (
-                np.nan_to_num(deriv_mobility / mobility)
-            )
+        activity = np.nan_to_num(var)
+        mobility = np.nan_to_num(np.sqrt(deriv1_var / var))
+        complexity = np.nan_to_num(deriv1_mobility / mobility)
+
+        for ch_idx, ch_name in enumerate(self.ch_names):
+            features_compute[f"{ch_name}_RawHjorth_Activity"] = activity[ch_idx]
+            features_compute[f"{ch_name}_RawHjorth_Mobility"] = mobility[ch_idx]
+            features_compute[f"{ch_name}_RawHjorth_Complexity"] = complexity[ch_idx]
 
         return features_compute
 

--- a/py_neuromodulation/nm_linelength.py
+++ b/py_neuromodulation/nm_linelength.py
@@ -1,31 +1,19 @@
 import numpy as np
-from collections.abc import Iterable
+from collections.abc import Sequence
 
 from py_neuromodulation.nm_features import NMFeature
 
 
 class LineLength(NMFeature):
-    def __init__(self, settings: dict, ch_names: Iterable[str], sfreq: float) -> None:
-        self.settings = settings
+    def __init__(self, settings: dict, ch_names: Sequence[str], sfreq: float) -> None:
         self.ch_names = ch_names
 
-    @staticmethod
-    def get_line_length(x: np.ndarray) -> np.floating:
-        return np.mean(np.abs(np.diff(x)) / (x.shape[0] - 1))
-
-    @staticmethod
-    def test_settings(
-        settings: dict,
-        ch_names: Iterable[str],
-        sfreq: float,
-    ):
-        # no settings to be checked
-        pass
-
     def calc_feature(self, data: np.ndarray, features_compute: dict) -> dict:
+        line_length = np.mean(
+            np.abs(np.diff(data, axis=-1)) / (data.shape[1] - 1), axis=-1
+        )
+
         for ch_idx, ch_name in enumerate(self.ch_names):
-            features_compute["_".join([ch_name, "LineLength"])] = self.get_line_length(
-                data[ch_idx, :]
-            )
+            features_compute[f"{ch_name}_LineLength"] = line_length[ch_idx]
 
         return features_compute


### PR DESCRIPTION
So I was looking at the profiling info, and I was quite happy that Bursts and Sharpwaves are now as fast as Hjorth. But after messing with Bursts and Sharpwaves for so many hours, I know that they're very complex features, so how come Hjorth is taking so long? Is it also super-complex?

Well it turns out no, it was just doing quite a lot of redundant work so I streamlined it a bit, which brought the computation time to 20% of the previous code, or a 5x speed-up.

Summary of changes:
- Do all the `diff`, `var` and `sqrt` calculations step-wise storing intermediate results to avoid repeating calculations
- Use the `axis` argument to run the calculations on the entire dataset at once, rather than 1 channel at a time
- Call `nan_to_num()` only once at the very end, it's more efficiente and also safer (intermediate `nan_to_num()` calls might result in divisions by zero, which result in `inf`, which `nan_to_num()` will replace with the largest possible value for the corresponding `dtype`)
- I added the literature reference at the beginning of the file, I believe it's the correct reference, would you mind double-checking @timonmerk ?

EDIT: did the same for LineLength, basically just applying the numpy functions directly to the 2D matrix, got a ~3x speed increase, although this feature was already very cheap.

EDIT2: just for reference, we're at this speed of computing for the default settings:
```Total time to process 10.0s of data with 5 channels: 5.7076427936553955 seconds per run.```
And I still have some aces up my sleeve, but I think the low hanging fruit has been more or less covered to I'm changing focus to GUI for now.