### PR TITLE
MNE connectivity 2x speed-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,14 @@ figures_ucsf/*
 catboost_info/*
 out_per
 .DS_Store
+
+# Temp dev files
+# Testing scripts
+/*.py 
+# Stream output
+/*.csv
+/*.db
+/*.sqlite
+# Profiler files
+/*.prof
+/profiling/*

--- a/py_neuromodulation/nm_mne_connectivity.py
+++ b/py_neuromodulation/nm_mne_connectivity.py
@@ -97,24 +97,20 @@ class MNEConnectivity(NMFeature):
 
         spec_out = self.estimate_connectivity(epochs)
 
-        if not self.fband_ranges:
+        if len(self.fband_ranges) == 0:
             for fband_name, fband_range in self.fbands.items():
                 self.fband_ranges.append(
                     np.where(
-                        np.logical_and(
-                            np.array(spec_out.freqs) > fband_range[0],
-                            np.array(spec_out.freqs) < fband_range[1],
-                        )
+                        (np.array(spec_out.freqs) > fband_range[0])
+                        & (np.array(spec_out.freqs) < fband_range[1])
                     )[0]
                 )
 
         dat_conn: np.ndarray = spec_out.get_data()
-
         for fband_idx, fband in enumerate(self.fbands):
-            conn_mean = np.mean(dat_conn, axis=0)
-            
+            fband_mean = np.mean(dat_conn[:, self.fband_ranges[fband_idx]], axis=1)
             for conn in np.arange(dat_conn.shape[0]):
                 key = "_".join(["ch1", self.method, str(conn), fband])
-                features_compute[key] =conn_mean[self.fband_ranges[fband_idx]]
+                features_compute[key] = fband_mean[conn]
 
         return features_compute

--- a/py_neuromodulation/nm_mne_connectivity.py
+++ b/py_neuromodulation/nm_mne_connectivity.py
@@ -8,7 +8,6 @@ from py_neuromodulation.nm_types import NMBaseModel
 
 if TYPE_CHECKING:
     from py_neuromodulation.nm_settings import NMSettings
-    from mne import Epochs
     from mne.io import RawArray
 
 
@@ -26,11 +25,14 @@ class MNEConnectivity(NMFeature):
     ) -> None:
         from mne import create_info
 
-        self.ch_names = ch_names
         self.settings = settings
+        
+        self.ch_names = ch_names
+        self.sfreq = sfreq
+        
+        # Params used by spectral_connectivity_epochs
         self.mode = settings.mne_connectivity.mode
         self.method = settings.mne_connectivity.method
-        self.sfreq = sfreq
 
         self.fbands = settings.frequency_ranges_hz
         self.fband_ranges: list = []
@@ -40,6 +42,8 @@ class MNEConnectivity(NMFeature):
         self.raw_array: "RawArray"
         self.events: np.ndarray
         self.prev_batch_shape: tuple = (-1, -1)  # sentinel value
+        self.prev_sfreq = self.sfreq
+        self.ch_names = ch_names
 
     def calc_feature(self, data: np.ndarray, features_compute: dict) -> dict:
         from mne.io import RawArray
@@ -47,7 +51,7 @@ class MNEConnectivity(NMFeature):
         from mne_connectivity import spectral_connectivity_epochs
 
         time_samples_s = data.shape[1] / self.sfreq
-        epoch_length: float = 1  # TODO: Make this a parameter
+        epoch_length: float = 1  # TODO: Make this a parameter?
 
         if epoch_length > time_samples_s:
             raise ValueError(
@@ -55,7 +59,9 @@ class MNEConnectivity(NMFeature):
                 f" are longer than the passed data array {np.round(time_samples_s, 2)}s"
             )
 
-        if data.shape != self.prev_batch_shape:
+        # Only reinitialize the raw_array and epochs object if the data shape has changed
+        # That could mean that the channels have been re-selected, or we're in the last batch
+        if data.shape != self.prev_batch_shape or self.prev_sfreq != self.sfreq:
             self.raw_array = RawArray(
                 data=data,
                 info=self.raw_info,
@@ -63,9 +69,7 @@ class MNEConnectivity(NMFeature):
                 verbose=False,
             )
 
-            # self.events = make_fixed_length_events(
-            #     self.raw_array, duration=epoch_length, overlap=0
-            # )
+            # self.events = make_fixed_length_events(self.raw_array, duration=epoch_length)
             # Equivalnet code for those parameters:
             self.events = np.column_stack(
                 (
@@ -94,14 +98,13 @@ class MNEConnectivity(NMFeature):
                 verbose=False,
             )
 
-            self.epochs.metadata = pd.DataFrame(
-                index=np.arange(self.events.shape[0]), columns=["column1", "column2"]
-            )
+            # Trick the function "spectral_connectivity_epochs" into not calling "add_annotations_to_metadata"
+            self.epochs._metadata = pd.DataFrame(index=np.arange(self.events.shape[0]))
 
         else:
-            # self.raw_array._data = data
             # As long as the initialization parameters, channels, sfreq and batch size are the same
             # We can re-use the existing epochs object by updating the raw data
+            self.raw_array._data = data
             self.epochs._raw = self.raw_array
 
         # n_jobs is here kept to 1, since setup of the multiprocessing Pool
@@ -134,6 +137,8 @@ class MNEConnectivity(NMFeature):
                 key = "_".join(["ch1", self.method, str(conn), fband])
                 features_compute[key] = fband_mean[conn]
 
+        # Store current experiment parameters to check if re-initialization is needed
         self.prev_batch_shape = data.shape
+        self.prev_sfreq = self.sfreq
 
         return features_compute

--- a/py_neuromodulation/nm_mne_connectivity.py
+++ b/py_neuromodulation/nm_mne_connectivity.py
@@ -89,7 +89,6 @@ class MNEConnectivity(NMFeature):
         return spec_out
 
     def calc_feature(self, data: np.ndarray, features_compute: dict) -> dict:
-        
         time_samples_s = data.shape[1] / self.sfreq
 
         epochs = self.get_epoched_data(data, time_samples_s=time_samples_s)
@@ -109,11 +108,13 @@ class MNEConnectivity(NMFeature):
                     )[0]
                 )
 
-        dat_conn = spec_out.get_data()
-        for conn in np.arange(dat_conn.shape[0]):
-            for fband_idx, fband in enumerate(self.fbands):
-                features_compute["_".join(["ch1", self.method, str(conn), fband])] = (
-                    np.mean(dat_conn[conn, self.fband_ranges[fband_idx]])
-                )
+        dat_conn: np.ndarray = spec_out.get_data()
+
+        for fband_idx, fband in enumerate(self.fbands):
+            conn_mean = np.mean(dat_conn, axis=0)
+            
+            for conn in np.arange(dat_conn.shape[0]):
+                key = "_".join(["ch1", self.method, str(conn), fband])
+                features_compute[key] =conn_mean[self.fband_ranges[fband_idx]]
 
         return features_compute


### PR DESCRIPTION
I know you're expecting news on the GUI, but since I wanted to present also about the speed optimizations next week and I know that some people involved in the MNE package might be around the lab I did some investigation in one of the 3 features that were still weighing us down too much for real-time processing: MNE connectivity (the other 2 being Bispectra and FOOOF)

So I realized that Epochs.__init__() and RawArray.__init__() were taking so much computation time, that I wondered whether running the constructors every time was even doing anything. So I went through all the lines of code taking notes and figured, no, the 200-300 lines of constructor for each class are doing nothing for us at least with our current parameters. So I basically bypassed those by just replacing the Numpy array that they were holding.

I also noticed that the function `spectral_connectivity_epochs` was calling another function, `add_annotations_to_metadata`, that was doing some serious outsourcing to Pandas, which not only was super-slow, but was also doing 0 changes to the `Epochs.annotations` property that it was manipulating and that was also never used after that for anything. So I checked the conditional `if` statement that triggered the call to `add_annotations_to_metadata` and added a little hack that makes the condition fail so it's not called. But it's super-weird that I need to do that to get reasonable behavior from `spectral_connectivity_epochs`.

Anyway now MNE_connectivity `calc_feature()` takes less than 47% of the time it took before and now lands in terms of performance right between Sharpwaves and Bursts. So now there's only Bispectra to check out (FOOOF I have already investigated and there's no room for optimization there except if I go down some serious linear algebra rabbit-hole that I don't have time for right now, but that is quite exciting tbh)

- Before:
  - Total time to process 100.0s of data with 5 channels: 23.278204441070557 seconds per run.
  - Time spent in MNEConnectivity.calc_feature(): 16.8 s

- After:
  - Total time to process 100.0s of data with 5 channels: 14.833247423171997 seconds per run.
  - Time spent in MNEConnectivity.calc_feature(): 8.00 s


In fact, it could even be faster with the following change that I did for the mean calculation at the end of the function: 
```python
        for fband_idx, fband in enumerate(self.fbands):
            fband_mean = np.mean(dat_conn[:, self.fband_ranges[fband_idx]], axis=1)
            for conn in np.arange(dat_conn.shape[0]):
                key = "_".join(["ch1", self.method, str(conn), fband])
                features_compute[key] = fband_mean[conn]
```
So what that does is, computing the mean for all 4 "conn" subsets of data at the same time, so should make `np.mean` 4 times faster for this particular case. But when I did that, I got a couple output values that were 0.999999999.... instead of 1.0. Should be the same in principle, but after normalization, I get a couple `-3` values in the output festures CSV insetad of 0's. I have no idea what's going on, might be an issue with normalization? I think it deserves a check, because 0.9999999999 or 1.0 should not make that big a change in the final result.

Also, I have another question about the MNE-connectivity feature: how come the channels are hard-coded in the `calc_feature` function? 
I'm talking about this argument to `spectral_connectivity_epochs`: 
```indices=(np.array([0, 0, 1, 1]), np.array([2, 3, 2, 3])),```
which according to the docstring is:
```
If a bivariate method is called, each array for the seeds
        and targets should contain the channel indices for each bivariate
        connection
```
So what's up with that? What if the data has less channels? And if the seed channels are `[0, 0, 1, 1]`, how come the outputs are coded as `ch1` for all output features?:
```key = "_".join(["ch1", self.method, str(conn), fband])```

I have the feeling I'm either missing something or the code is. 

PS: Here the dev-diary notes I took about the changes I made:

```
calc_feature:
	- Do the RawArray initialization inside get_epoch_data, to avoid having to call .get_data()
	- Do we need to create_info everytime? I would assume the info is always the same
		○ it is indeed -> create only once
	- Bypass make_fixed_length_events by creating the events ourselves, as we don't make use of almost any of the parameters except epoch_length
	

Epochs constructor:
	- Why deepcopy info? info is never written to I think. Threading concerns? In any case, we have created info just before, so… no point. 
	- Arguments passed:
	            self.raw_array,
	            events=events,
	            event_id={"rest": 1},
	            tmin=0,
	            tmax=epoch_length,
	            baseline=None,
	            reject_by_annotation=True, # Default
	            verbose=False,
	- What is it doing?
		○ BaseRaw check not needed
		○ no annotations passed, persistent
		○ proj is false and persistent
		○ reject_by_annotation is True, but persistent
		○ sfreq is persistent
		○ events is NOT PERSISTENT, needs replacement, is passed to BaseEpochs constructor
	- BaseEpochs constructor
		○ _ensure_events, no need, we're creating them fine
		○ selected is useless cause it will select all anyway
		○ self.drop_log is useless, we're not dropping anything
		○ _handle_event_repeated is doing nothing otherwise it would error
		○ metadata is None, we're not doing anything with it
		○ we're not passing detrend
		○ self._raw is the raw data (line 584), first line that is relevant
		○ _picks_to_idx basically returns channel indices, seems persistent 
		○ data is none, these are set:
			        if data is None:
			            self.preload = False
			            self._data = None
			            self._do_baseline = True
		○ this is set: self._offset = None
		○ self._raw_times is persistent
		○ reject_tmin and reject_tmax are None, these parts are skipped
		○ self.decimate(decim) does nothing
			§ calls _set_times which changes self._times_readonly-> but no changes in times_readonly
		○ _check_baseline is doing nothing as well since Baseline is None
		○ More sets and _reject_setup called, but I'm pretty sure it does nothing: 
		        self.reject = None
		        self.flat = None
		○ Next comes proj section but it does nothing I think
		○ preload_at_end is false so load_data is not called
		○ _check_consistency() is unnecessary
		○ set_annotations is unnecessary

	- CONCLUSION: Epochs object can be re-used by just setting self._raw = raw

NOTE: Epochs would need reinitialization if settings, sfreq or channels change, but I imagine the whole stream would be re-initialized in that case.

spectral_connectivity_epochs()
	- _assemble_spectral_params takes the most time (22%) 
	
	- the SpectralConnectivity object constructor also takes a lot of time (10%)
	- add_annotations_to_metadata  takes very long (11%) but does nothing.
		○ to prevent the function from being called, annots_in_metadata needs to be True.
		○ For that, all names in ["annot_onset", "annot_duration", "annot_description"] need to be missing from metadata.columns
		
	- _epoch_spectral_connectivity (6%)
	- _get_n_epochs loops over sth, takes (4.5%)
```
