### PR TITLE
Remove features dictionary as input to calc_feature

### DIFF
--- a/examples/plot_2_example_add_feature.py
+++ b/examples/plot_2_example_add_feature.py
@@ -37,18 +37,21 @@ class ChannelMean:
         
         self.feature_name = "channel_mean"
 
-    def calc_feature(self, data: np.ndarray, features_compute: dict) -> dict:
+    def calc_feature(self, data: np.ndarray) -> dict:
+        # First, create an empty dictionary to store the calculated features
+        feature_results = {}
+
         # Here you can add any feature calculation code
         # This example simply calculates the mean signal for each channel
         ch_means = np.mean(data, axis=1)
 
-        # Store the calculated features in the features_compute dictionary
+        # Store the calculated features in the feature_results dictionary
         # Be careful to use a unique keyfor each channel and metric you compute
         for ch_idx, ch in enumerate(self.ch_names):
-            features_compute[f"{self.feature_name}_{ch}"] = ch_means[ch_idx]
+            feature_results[f"{self.feature_name}_{ch}"] = ch_means[ch_idx]
 
-        # Return the updated features_compute dictionary to the stream
-        return features_compute
+        # Return the updated feature_results dictionary to the stream
+        return feature_results
 
 
 nm.add_custom_feature("channel_mean", ChannelMean)

--- a/py_neuromodulation/nm_bispectra.py
+++ b/py_neuromodulation/nm_bispectra.py
@@ -86,7 +86,7 @@ class Bispectra(NMFeature):
     
         # self.freqs: np.ndarray = np.array([]) # In case we pre-computed this
 
-    def calc_feature(self, data: np.ndarray, features_compute: dict) -> dict:
+    def calc_feature(self, data: np.ndarray) -> dict:
         from pybispectra import compute_fft, WaveShape
 
         # PyBispectra's compute_fft uses PQDM to parallelize the calculation per channel
@@ -120,7 +120,8 @@ class Bispectra(NMFeature):
             f1s=tuple(self.settings.f1s),  # type: ignore
             f2s=tuple(self.settings.f2s),  # type: ignore
         )
-
+        
+        feature_results = {}
         for ch_idx, ch_name in enumerate(self.ch_names):
             
             bispectrum = waveshape._bicoherence[ch_idx]  # Same as waveshape.results._data, skips a copy
@@ -136,13 +137,13 @@ class Bispectra(NMFeature):
                     data_bs = spectrum_ch[range_, range_]
 
                     for bispectrum_feature in self.used_features:
-                        features_compute[
+                        feature_results[
                             f"{ch_name}_Bispectrum_{component}_{bispectrum_feature}_{fb}"
                         ] = FEATURE_DICT[bispectrum_feature](data_bs)
 
                         if self.settings.compute_features_for_whole_fband_range:
-                            features_compute[
+                            feature_results[
                                 f"{ch_name}_Bispectrum_{component}_{bispectrum_feature}_whole_fband_range"
                             ] = FEATURE_DICT[bispectrum_feature](spectrum_ch)
 
-        return features_compute
+        return feature_results

--- a/py_neuromodulation/nm_bursts.py
+++ b/py_neuromodulation/nm_bursts.py
@@ -136,7 +136,7 @@ class Burst(NMFeature):
         self.label_structure_matrix = np.zeros((3, 3, 3))
         self.label_structure_matrix[1, 1, :] = 1
 
-    def calc_feature(self, data: np.ndarray, features_compute: dict) -> dict:
+    def calc_feature(self, data: np.ndarray) -> dict:
         from scipy.signal import hilbert
         from scipy.ndimage import label, sum_labels as label_sum, mean as label_mean
 
@@ -246,40 +246,41 @@ class Burst(NMFeature):
             self.end_in_burst = bursts[:, :, -1]  # End in burst
 
         # Create dictionary of features which is the correct return format
+        feature_results = {}
         for (ch_i, ch), (fb_i, fb), feat in self.feature_combinations:
-            self.STORE_FEAT_DICT[feat](features_compute, ch_i, ch, fb_i, fb)
+            self.STORE_FEAT_DICT[feat](feature_results, ch_i, ch, fb_i, fb)
 
-        return features_compute
+        return feature_results
 
     def store_duration(
-        self, features_compute: dict, ch_i: int, ch: str, fb_i: int, fb: str
+        self, feature_results: dict, ch_i: int, ch: str, fb_i: int, fb: str
     ):
-        features_compute[f"{ch}_bursts_{fb}_duration_mean"] = self.burst_duration_mean[
+        feature_results[f"{ch}_bursts_{fb}_duration_mean"] = self.burst_duration_mean[
             ch_i, fb_i
         ]
 
-        features_compute[f"{ch}_bursts_{fb}_duration_max"] = self.burst_duration_max[
+        feature_results[f"{ch}_bursts_{fb}_duration_max"] = self.burst_duration_max[
             ch_i, fb_i
         ]
 
     def store_amplitude(
-        self, features_compute: dict, ch_i: int, ch: str, fb_i: int, fb: str
+        self, feature_results: dict, ch_i: int, ch: str, fb_i: int, fb: str
     ):
-        features_compute[f"{ch}_bursts_{fb}_amplitude_mean"] = (
+        feature_results[f"{ch}_bursts_{fb}_amplitude_mean"] = (
             self.burst_amplitude_mean[ch_i, fb_i]
         )
-        features_compute[f"{ch}_bursts_{fb}_amplitude_max"] = self.burst_amplitude_max[
+        feature_results[f"{ch}_bursts_{fb}_amplitude_max"] = self.burst_amplitude_max[
             ch_i, fb_i
         ]
 
     def store_burst_rate(
-        self, features_compute: dict, ch_i: int, ch: str, fb_i: int, fb: str
+        self, feature_results: dict, ch_i: int, ch: str, fb_i: int, fb: str
     ):
-        features_compute[f"{ch}_bursts_{fb}_burst_rate_per_s"] = self.burst_rate_per_s[
+        feature_results[f"{ch}_bursts_{fb}_burst_rate_per_s"] = self.burst_rate_per_s[
             ch_i, fb_i
         ]
 
     def store_in_burst(
-        self, features_compute: dict, ch_i: int, ch: str, fb_i: int, fb: str
+        self, feature_results: dict, ch_i: int, ch: str, fb_i: int, fb: str
     ):
-        features_compute[f"{ch}_bursts_{fb}_in_burst"] = self.end_in_burst[ch_i, fb_i]
+        feature_results[f"{ch}_bursts_{fb}_in_burst"] = self.end_in_burst[ch_i, fb_i]

--- a/py_neuromodulation/nm_coherence.py
+++ b/py_neuromodulation/nm_coherence.py
@@ -68,7 +68,7 @@ class CoherenceObject:
         self.coh_val = None
         self.icoh_val = None
 
-    def get_coh(self, features_compute, x, y):
+    def get_coh(self, feature_results, x, y):
         from scipy.signal import welch, csd
 
         self.f, self.Pxx = welch(x, self.sfreq, self.window, nperseg=128)
@@ -104,7 +104,7 @@ class CoherenceObject:
                             self.fband_names[idx],
                         ]
                     )
-                    features_compute[feature_name] = feature_calc
+                    feature_results[feature_name] = feature_calc
                 if self.features_coh.max_fband:
                     feature_calc = np.max(
                         coh_val[np.bitwise_and(self.f > fband[0], self.f < fband[1])]
@@ -119,7 +119,7 @@ class CoherenceObject:
                             self.fband_names[idx],
                         ]
                     )
-                    features_compute[feature_name] = feature_calc
+                    feature_results[feature_name] = feature_calc
             if self.features_coh.max_allfbands:
                 feature_calc = self.f[np.argmax(coh_val)]
                 feature_name = "_".join(
@@ -132,8 +132,8 @@ class CoherenceObject:
                         self.fband_names[idx],
                     ]
                 )
-                features_compute[feature_name] = feature_calc
-        return features_compute
+                feature_results[feature_name] = feature_calc
+        return feature_results
 
 
 class NMCoherence(NMFeature):
@@ -235,12 +235,14 @@ class NMCoherence(NMFeature):
                 "feature coherence enabled, but no coherence['method'] selected"
             )
 
-    def calc_feature(self, data: np.ndarray, features_compute: dict) -> dict:
+    def calc_feature(self, data: np.ndarray) -> dict:
+        feature_results = {}
+
         for coh_obj in self.coherence_objects:
-            features_compute = coh_obj.get_coh(
-                features_compute,
+            feature_results = coh_obj.get_coh(
+                feature_results,
                 data[coh_obj.ch_1_idx, :],
                 data[coh_obj.ch_2_idx, :],
             )
 
-        return features_compute
+        return feature_results

--- a/py_neuromodulation/nm_features.py
+++ b/py_neuromodulation/nm_features.py
@@ -50,18 +50,17 @@ FEATURE_DICT: dict[FeatureName | str, ImportDetails] = {
 
 
 class FeatureProcessors:
-    """Class for calculating features.p"""
+    """Class for storing NMFeature objects and calculating features during processing"""
 
     def __init__(
         self, settings: "NMSettings", ch_names: list[str], sfreq: float
     ) -> None:
-        """_summary_
+        """Initialize FeatureProcessors object with settings, channel names and sampling frequency.
 
-        Parameters
-        ----------
-        settings : nm_settings.NMSettings
-        ch_names : list[str]
-        sfreq : float
+        Args:
+            settings (NMSettings): PyNM settings object
+            ch_names (list[str]): list of channel names
+            sfreq (float): sampling frequency in Hz
         """
         from py_neuromodulation import user_features
 

--- a/py_neuromodulation/nm_features.py
+++ b/py_neuromodulation/nm_features.py
@@ -1,8 +1,8 @@
 from typing import Protocol, Type, runtime_checkable, TYPE_CHECKING, TypeVar
 from collections.abc import Sequence
+import numpy as np
 
 if TYPE_CHECKING:
-    import numpy as np
     from nm_settings import NMSettings
 
 from py_neuromodulation.nm_types import ImportDetails, get_class, FeatureName
@@ -14,19 +14,19 @@ class NMFeature(Protocol):
         self, settings: "NMSettings", ch_names: Sequence[str], sfreq: int | float
     ) -> None: ...
 
-    def calc_feature(self, data: "np.ndarray", features_compute: dict) -> dict:
+    def calc_feature(self, data: np.ndarray) -> dict:
         """
-        Feature calculation method. Each method needs to loop through all channels
+            Feature calculation method. Each method needs to loop through all channels
 
         Parameters
-        ----------
-        data : 'np.ndarray'
-            (channels, time)
-        features_compute : dict
+            ----------
+            data : 'np.ndarray'
+                (channels, time)
+            feature_results : dict
 
-        Returns
-        -------
-        dict
+            Returns
+            -------
+            dict
         """
         ...
 
@@ -86,7 +86,7 @@ class FeatureProcessors:
         """
         self.features[feature_name] = feature  # type: ignore
 
-    def estimate_features(self, data: "np.ndarray") -> dict:
+    def estimate_features(self, data: np.ndarray) -> dict:
         """Calculate features, as defined in settings.json
         Features are based on bandpower, raw Hjorth parameters and sharp wave
         characteristics.
@@ -100,15 +100,12 @@ class FeatureProcessors:
         dat (dict): naming convention : channel_method_feature_(f_band)
         """
 
-        features_compute: dict = {}
+        feature_results: dict = {}
 
         for feature in self.features.values():
-            features_compute = feature.calc_feature(
-                data,
-                features_compute,
-            )
+            feature_results.update(feature.calc_feature(data))
 
-        return features_compute
+        return feature_results
 
     def get_feature(self, fname: FeatureName) -> NMFeature:
         return self.features[fname]

--- a/py_neuromodulation/nm_hjorth_raw.py
+++ b/py_neuromodulation/nm_hjorth_raw.py
@@ -5,6 +5,7 @@ Reference:  B Hjorth
             DOI: 10.1016/0013-4694(70)90143-4
 """
 
+from pyexpat import features
 import numpy as np
 from collections.abc import Iterable
 
@@ -18,7 +19,7 @@ class Hjorth(NMFeature):
     ) -> None:
         self.ch_names = ch_names
 
-    def calc_feature(self, data: np.ndarray, features_compute: dict) -> dict:
+    def calc_feature(self, data: np.ndarray) -> dict:
         var = np.var(data, axis=-1)
         deriv1 = np.diff(data, axis=-1)
         deriv2 = np.diff(deriv1, axis=-1)
@@ -30,24 +31,23 @@ class Hjorth(NMFeature):
         mobility = np.nan_to_num(np.sqrt(deriv1_var / var))
         complexity = np.nan_to_num(deriv1_mobility / mobility)
 
+        feature_results = {}
         for ch_idx, ch_name in enumerate(self.ch_names):
-            features_compute[f"{ch_name}_RawHjorth_Activity"] = activity[ch_idx]
-            features_compute[f"{ch_name}_RawHjorth_Mobility"] = mobility[ch_idx]
-            features_compute[f"{ch_name}_RawHjorth_Complexity"] = complexity[ch_idx]
+            feature_results[f"{ch_name}_RawHjorth_Activity"] = activity[ch_idx]
+            feature_results[f"{ch_name}_RawHjorth_Mobility"] = mobility[ch_idx]
+            feature_results[f"{ch_name}_RawHjorth_Complexity"] = complexity[ch_idx]
 
-        return features_compute
+        return feature_results
 
 
 class Raw(NMFeature):
     def __init__(self, settings: dict, ch_names: Iterable[str], sfreq: float) -> None:
         self.ch_names = ch_names
 
-    def calc_feature(
-        self,
-        data: np.ndarray,
-        features_compute: dict,
-    ) -> dict:
-        for ch_idx, ch_name in enumerate(self.ch_names):
-            features_compute["_".join([ch_name, "raw"])] = data[ch_idx, -1]
+    def calc_feature(self, data: np.ndarray) -> dict:
+        feature_results = {}
 
-        return features_compute
+        for ch_idx, ch_name in enumerate(self.ch_names):
+            feature_results["_".join([ch_name, "raw"])] = data[ch_idx, -1]
+
+        return feature_results

--- a/py_neuromodulation/nm_linelength.py
+++ b/py_neuromodulation/nm_linelength.py
@@ -8,12 +8,14 @@ class LineLength(NMFeature):
     def __init__(self, settings: dict, ch_names: Sequence[str], sfreq: float) -> None:
         self.ch_names = ch_names
 
-    def calc_feature(self, data: np.ndarray, features_compute: dict) -> dict:
+    def calc_feature(self, data: np.ndarray) -> dict:
+
         line_length = np.mean(
             np.abs(np.diff(data, axis=-1)) / (data.shape[1] - 1), axis=-1
         )
 
+        feature_results = {}
         for ch_idx, ch_name in enumerate(self.ch_names):
-            features_compute[f"{ch_name}_LineLength"] = line_length[ch_idx]
+            feature_results[f"{ch_name}_LineLength"] = line_length[ch_idx]
 
-        return features_compute
+        return feature_results

--- a/py_neuromodulation/nm_mne_connectivity.py
+++ b/py_neuromodulation/nm_mne_connectivity.py
@@ -44,7 +44,7 @@ class MNEConnectivity(NMFeature):
         self.epochs: "Epochs"
         self.prev_batch_shape: tuple = (-1, -1)  # sentinel value
 
-    def calc_feature(self, data: np.ndarray, features_compute: dict) -> dict:
+    def calc_feature(self, data: np.ndarray) -> dict:
         from mne.io import RawArray
         from mne import Epochs
         from mne_connectivity import spectral_connectivity_epochs
@@ -136,13 +136,14 @@ class MNEConnectivity(NMFeature):
         # TODO: If I compute the mean for the entire fband, results are almost the same before
         # normalization (0.9999999... vs 1.0), but some change wildly after normalization (-3 vs 0)
         # Investigate why, is this a bug in normalization?
+        feature_results = {}
         for conn in np.arange(dat_conn.shape[0]):
             for fband_idx, fband in enumerate(self.fbands):
-                features_compute["_".join(["ch1", self.method, str(conn), fband])] = (
+                feature_results["_".join(["ch1", self.method, str(conn), fband])] = (
                     np.mean(dat_conn[conn, self.fband_ranges[fband_idx]])
                 )
 
         # Store current experiment parameters to check if re-initialization is needed
         self.prev_batch_shape = data.shape
 
-        return features_compute
+        return feature_results

--- a/py_neuromodulation/nm_run_analysis.py
+++ b/py_neuromodulation/nm_run_analysis.py
@@ -16,7 +16,7 @@ class DataProcessor:
     def __init__(
         self,
         sfreq: float,
-        settings: "NMSettings | _PathLike",
+        settings: NMSettings | _PathLike,
         nm_channels: pd.DataFrame | _PathLike,
         coord_names: list | None = None,
         coord_list: list | None = None,

--- a/tests/test_bursts.py
+++ b/tests/test_bursts.py
@@ -82,13 +82,13 @@ def test_bursting_duration():
     for _ in range(10):
         np.random.seed(0)
         data = np.random.random([NUM_CH, 1 * sfreq])
-        f = bursts.calc_feature(data, {})
+        f = bursts.calc_feature(data)
 
     np.random.seed(0)
     # the percentile of the hilbert transform of a continuous oscillation will be high
     # select better max amplitude
     bursts = nm_bursts.Burst(settings, ch_names, sfreq)
-    f_burst = bursts.calc_feature(beta_wave + np.random.random([NUM_CH, 1 * sfreq]), {})
+    f_burst = bursts.calc_feature(beta_wave + np.random.random([NUM_CH, 1 * sfreq]))
 
     assert (
         f["ch0_bursts_low beta_amplitude_max"]

--- a/tests/test_osc_features.py
+++ b/tests/test_osc_features.py
@@ -79,7 +79,7 @@ def test_fft_zero_data():
     fft_obj = nm_oscillatory.FFT(settings, ch_names, sfreq)
 
     data = np.ones([len(ch_names), sfreq])
-    features_out = fft_obj.calc_feature(data, {})
+    features_out = fft_obj.calc_feature(data)
 
     for f in features_out.keys():
         if "psd_0" not in f:
@@ -101,7 +101,7 @@ def test_fft_random_data():
     fft_obj = nm_oscillatory.FFT(settings, ch_names, sfreq)
 
     data = np.random.random([len(ch_names), sfreq])
-    features_out = fft_obj.calc_feature(data, {})
+    features_out = fft_obj.calc_feature(data)
 
     for f in features_out.keys():
         assert features_out[f] != 0
@@ -138,7 +138,7 @@ def test_fft_beta_osc():
     np.random.seed(0)
     data = np.random.random([len(ch_names), sfreq]) + beta_wave
 
-    features_out = fft_obj.calc_feature(data, {})
+    features_out = fft_obj.calc_feature(data)
 
     assert (
         features_out["ch1_fft_beta_mean"] > features_out["ch1_fft_theta_mean"]
@@ -210,7 +210,7 @@ def test_stft_beta_osc():
     np.random.seed(0)
     data = np.random.random([len(ch_names), sfreq]) + beta_wave
 
-    features_out = stft_obj.calc_feature(data, {})
+    features_out = stft_obj.calc_feature(data)
 
     assert (
         features_out["ch1_stft_beta_mean"] > features_out["ch1_stft_theta_mean"]
@@ -249,7 +249,7 @@ def test_welch_beta_osc():
     np.random.seed(0)
     data = np.random.random([len(ch_names), sfreq]) + beta_wave
 
-    features_out = stft_obj.calc_feature(data, {})
+    features_out = stft_obj.calc_feature(data)
 
     assert (
         features_out["ch1_welch_beta_mean"] > features_out["ch1_welch_theta_mean"]
@@ -335,7 +335,7 @@ def test_bp_zero_data():
     stft_obj = nm_oscillatory.BandPower(settings, ch_names, sfreq)
 
     data = np.zeros([len(ch_names), sfreq])
-    features_out = stft_obj.calc_feature(data, {})
+    features_out = stft_obj.calc_feature(data)
 
     for f in features_out.keys():
         assert pytest.approx(0, 0.01) == features_out[f]
@@ -360,7 +360,7 @@ def test_bp_random_data():
 
     np.random.seed(0)
     data = np.random.random([len(ch_names), sfreq])
-    features_out = stft_obj.calc_feature(data, {})
+    features_out = stft_obj.calc_feature(data)
 
     for f in features_out.keys():
         assert pytest.approx(0, 0.01) != features_out[f]
@@ -402,7 +402,7 @@ def test_bp_beta_osc():
     np.random.seed(0)
     data = np.random.random([len(ch_names), sfreq]) + beta_wave
 
-    features_out = bp_obj.calc_feature(data, {})
+    features_out = bp_obj.calc_feature(data)
 
     assert (
         features_out["ch1_bandpass_activity_beta"]

--- a/tests/test_sharpwave.py
+++ b/tests/test_sharpwave.py
@@ -82,7 +82,7 @@ def test_prominence_features():
     data[2, 500] = 3
     data[3, 500] = 4
 
-    features = sw.calc_feature(data, {})
+    features = sw.calc_feature(data)
 
     assert (
         features["ch4_Sharpwave_Max_prominence_range_5_80"]
@@ -118,7 +118,7 @@ def test_interval_feature():
     for i in np.arange(0, 1000, 400):
         data[3, i] = 1
 
-    features = sw.calc_feature(data, {})
+    features = sw.calc_feature(data)
 
     print(features.keys())
     assert (


### PR DESCRIPTION
The calculation of each feature is independent of the rest, so having "features_compute" as an input argument to `calc_feature` suggested otherwise and was not necessary. It might also pose problems if we decide to multi-thread the feature calculation at the `DataProcessor` or `FeatureProcessors` level.