### PR TITLE
add start and stop of stream

### DIFF
--- a/gui_dev/package.json
+++ b/gui_dev/package.json
@@ -30,14 +30,14 @@
     "@vitejs/plugin-react": "^4.3.1",
     "@welldone-software/why-did-you-render": "^8.0.3",
     "babel-plugin-react-compiler": "latest",
-    "eslint": "^9.10.0",
+    "eslint": "^9.11.0",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-jsdoc": "^50.2.3",
+    "eslint-plugin-jsdoc": "^50.2.4",
     "eslint-plugin-react": "^7.36.1",
     "eslint-plugin-react-compiler": "latest",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.12",
     "prettier": "^3.3.3",
-    "vite": "^5.4.6"
+    "vite": "^5.4.7"
   }
 }

--- a/gui_dev/package.json
+++ b/gui_dev/package.json
@@ -30,14 +30,14 @@
     "@vitejs/plugin-react": "^4.3.1",
     "@welldone-software/why-did-you-render": "^8.0.3",
     "babel-plugin-react-compiler": "latest",
-    "eslint": "^9.11.0",
+    "eslint": "^9.11.1",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-jsdoc": "^50.2.4",
-    "eslint-plugin-react": "^7.36.1",
+    "eslint-plugin-jsdoc": "^50.3.0",
+    "eslint-plugin-react": "^7.37.0",
     "eslint-plugin-react-compiler": "latest",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.12",
     "prettier": "^3.3.3",
-    "vite": "^5.4.7"
+    "vite": "^5.4.8"
   }
 }

--- a/gui_dev/src/pages/Dashboard.jsx
+++ b/gui_dev/src/pages/Dashboard.jsx
@@ -1,8 +1,19 @@
 import { Graph } from "@/components";
-import { Box } from "@mui/material";
+import { Box, Button } from "@mui/material";
+import { useSessionStore } from "@/stores";
 
-export const Dashboard = () => (
-  <Box>
-    <Graph />
-  </Box>
-);
+export const Dashboard = () => {
+  
+  const startStream = useSessionStore((state) => state.startStream);
+  const stopStream = useSessionStore((state) => state.stopStream);
+
+  return(
+    <>
+    <Button variant="contained" onClick={startStream}> Run stream</Button>
+      <Button variant="contained" onClick={stopStream}> Stop stream</Button>
+    <Box>
+      <Graph />
+    </Box>
+  </>
+  )
+}

--- a/gui_dev/src/pages/Settings/Settings.jsx
+++ b/gui_dev/src/pages/Settings/Settings.jsx
@@ -259,10 +259,10 @@ export const Settings = () => {
         variant="contained"
         component={Link}
         color="primary"
-        to="/decoding"
+        to="/dashboard"
         sx={{ mt: 2 }}
       >
-        Run Stream
+        Start Stream
       </Button>
     </Stack>
   );

--- a/gui_dev/src/stores/sessionStore.js
+++ b/gui_dev/src/stores/sessionStore.js
@@ -247,6 +247,54 @@ export const useSessionStore = createPersistStore("session", (set, get) => ({
     );
   },
 
+  startStream: async () => {
+    try {
+      console.log("Start Stream");
+
+      const response = await fetch("/api/stream-control", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        // This needs to be adapted depending on the backend changes
+        body: JSON.stringify({ "action" : "start"}),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed start stream: ${await response.text()}`);
+      }
+
+      const result = await response.json();
+      console.log("Stream started:", result);
+    } catch (error) {
+      console.error("Failed to start stream:", error);
+    }
+  },
+
+  stopStream: async () => {
+    try {
+      console.log("Stop Stream");
+
+      const response = await fetch("/api/stream-control-stop", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        // This needs to be adapted depending on the backend changes
+        body: JSON.stringify({ "action" : "stop"}),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed stopping stream: ${await response.text()}`);
+      }
+
+      const result = await response.json();
+      console.log("Stream Stopping:", result);
+    } catch (error) {
+      console.error("Failed to stop stream:", error);
+    }
+  },
+
   resetSession: () =>
     get().setStateAndSync({
       sourceType: null,

--- a/py_neuromodulation/gui/backend/app_pynm.py
+++ b/py_neuromodulation/gui/backend/app_pynm.py
@@ -33,7 +33,7 @@ class PyNMState:
         # The stream will then put the results in the queue
         # there should be another websocket in which the results are sent to the frontend
 
-        stream_handling_queue = Queue()
+        self.stream_handling_queue = Queue()
 
         self.logger.info("setup stream Process")
 
@@ -54,7 +54,7 @@ class PyNMState:
         await self.stream.run(
             out_dir=out_dir,
             experiment_name=experiment_name,
-            stream_handling_queue=stream_handling_queue,
+            stream_handling_queue=self.stream_handling_queue,
             is_stream_lsl=self.lsl_stream_name is not None,
             stream_lsl_name=self.lsl_stream_name
             if self.lsl_stream_name is not None

--- a/py_neuromodulation/gui/backend/app_pynm.py
+++ b/py_neuromodulation/gui/backend/app_pynm.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import numpy as np
-from multiprocessing import Process, Queue
+from multiprocessing import Process
 
 from py_neuromodulation.stream import Stream, NMSettings
 from py_neuromodulation.utils import set_channels
@@ -33,7 +33,7 @@ class PyNMState:
         # The stream will then put the results in the queue
         # there should be another websocket in which the results are sent to the frontend
 
-        self.stream_handling_queue = Queue()
+        self.stream_handling_queue = asyncio.Queue()
 
         self.logger.info("setup stream Process")
 
@@ -51,15 +51,16 @@ class PyNMState:
         #     },
         # )
         #asyncio.run(
-        await self.stream.run(
-            out_dir=out_dir,
-            experiment_name=experiment_name,
-            stream_handling_queue=self.stream_handling_queue,
-            is_stream_lsl=self.lsl_stream_name is not None,
-            stream_lsl_name=self.lsl_stream_name
-            if self.lsl_stream_name is not None
-            else "",
-            websocket_featues=websocket_manager_features,
+        asyncio.create_task(self.stream.run(
+                out_dir=out_dir,
+                experiment_name=experiment_name,
+                stream_handling_queue=self.stream_handling_queue,
+                is_stream_lsl=self.lsl_stream_name is not None,
+                stream_lsl_name=self.lsl_stream_name
+                if self.lsl_stream_name is not None
+                else "",
+                websocket_featues=websocket_manager_features,
+            )
         )
 
         # self.logger.info("initialized run process")

--- a/py_neuromodulation/gui/backend/app_socket.py
+++ b/py_neuromodulation/gui/backend/app_socket.py
@@ -41,7 +41,7 @@ class WebSocketManager:
         if self.active_connections:
             for connection in self.active_connections:
                 if type(message) is dict:
-                    await connection.send_json(json.dump(message))
+                    await connection.send_json(message)
                 elif type(message) is str:
                     await connection.send_text(message)
             self.logger.info(f"Message sent")

--- a/py_neuromodulation/stream/stream.py
+++ b/py_neuromodulation/stream/stream.py
@@ -1,5 +1,6 @@
 """Module for generic and offline data streams."""
 
+import asyncio
 from typing import TYPE_CHECKING
 from collections.abc import Iterator
 import numpy as np
@@ -297,10 +298,12 @@ class Stream:
         prev_batch_end = 0
         for timestamps, data_batch in self.generator:
             self.is_running = True
+            await asyncio.sleep(0.001)
             if self.stream_handling_queue is not None:
+                nm.logger.info("Checking for stop signal")
                 if not self.stream_handling_queue.empty():
-                    value = self.stream_handling_queue.get()
-                    if value == "stop":
+                    stop_signal = await asyncio.wait_for(self.stream_handling_queue.get(), timeout=0.01)
+                    if stop_signal == "stop":
                         break
             if data_batch is None:
                 break

--- a/py_neuromodulation/stream/stream.py
+++ b/py_neuromodulation/stream/stream.py
@@ -258,11 +258,11 @@ class Stream:
         nm.logger.log_to_file(out_dir)
 
         # Initialize mp.Pool for multiprocessing
-        self.pool = mp.Pool(processes=self.settings.n_jobs)
+        #self.pool = mp.Pool(processes=self.settings.n_jobs)
         # Set up shared memory for multiprocessing
-        self.shared_memory = mp.Array(ctypes.c_double, self.settings.n_jobs * self.settings.n_jobs)
+        #self.shared_memory = mp.Array(ctypes.c_double, self.settings.n_jobs * self.settings.n_jobs)
         # Set up multiprocessing semaphores
-        self.semaphore = mp.Semaphore(self.settings.n_jobs)
+        #self.semaphore = mp.Semaphore(self.settings.n_jobs)
         
         # Initialize generator
         self.generator: Iterator
@@ -339,7 +339,8 @@ class Stream:
             if websocket_featues is not None:
                 nm.logger.info("Sending message to Websocket")
                 #nm.logger.info(feature_dict)
-                await websocket_featues.send_message(feature_dict)
+                #await websocket_featues.send_cbor(feature_dict)
+                #await websocket_featues.send_message(feature_dict)
             self.batch_count += 1
             if self.batch_count % self.save_interval == 0:
                 self.db.commit()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
   "uvicorn>=0.30.6",
   "websockets>=13.0",
   "seaborn >= 0.11",
+  "cbor2>=5.6.4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
WIP: I think we need to change the `async run` function. It blocks the `app_backend` until it completed, only afterwards it allows to call different fastAPI functions. 

I am not sure this basically means that the run function really needs to be called within a process, which didn't work because of pickling errors...