### PR TITLE
Fixed use of non-target/decoding channel in the combined setting

### DIFF
--- a/py_neuromodulation/analysis/decode.py
+++ b/py_neuromodulation/analysis/decode.py
@@ -168,7 +168,7 @@ class Decoder:
             self.feature_names = [
                 col
                 for col in self.features.columns
-                if not (("time" in col) or (self.label_name in col))
+                if any(col.startswith(used_ch) for used_ch in self.used_chs)
             ]
             self.data = np.nan_to_num(np.array(self.features[self.feature_names]))
 


### PR DESCRIPTION
For visualization purposes I included an extra channel in the feature array, which was neither a label nor a used channel. However, it was still included in the combined data array and thus, for decoding. The proposed change makes sure that only those channels that are also present in the used_ch list (and not all apart from the label and the time) are included in the combined dataset. 